### PR TITLE
Eliminated intermediate arrays and associated copying of data

### DIFF
--- a/scripts/netcdf_utils.py
+++ b/scripts/netcdf_utils.py
@@ -23,7 +23,7 @@ _logger = logging.getLogger(__name__)
 def initial_and_final_years(netcdf_file):
     """
     Gets the initial and final years represented by the time dimension/coordinate variable.
-    
+
     :param netcdf_file: a NetCDF file, assumed to a coordinate variables named 'time'
     :return: the years corresponding to the initial and final time values
     :rtype: integers
@@ -43,9 +43,9 @@ def initial_and_final_years(netcdf_file):
 def lat_and_lon_sizes(netcdf_file):
     """
     Gets the sizes of the latitude and longitude dimensions/coordinate variables.
-    
+
     :param netcdf_file: a NetCDF file, assumed to contain coordinate variables named 'lat' and 'lon'
-    :return: two values: the sizes of the latitude and longitude coordinate variables 
+    :return: two values: the sizes of the latitude and longitude coordinate variables
              (i.e. the number of lats and lons, respectively)
     :rtype: integers
     """


### PR DESCRIPTION
Eliminated intermediate arrays within parallelization functions for PET, SPEI, and Palmers, as well as removal of associated copying of data from intermediate arrays into the corresponding output shared memory arrays.

#210