### PR TITLE
Calendar conversion added back into process_grid.py for daily values

### DIFF
--- a/scripts/process_divisions.py
+++ b/scripts/process_divisions.py
@@ -514,7 +514,9 @@ def _compute_write_index(keyword_arguments):
                 dataset[precip_var_name].values *= 25.4
             else:
                 raise ValueError(
-                    "Unsupported precipitation units: {var}".format(var=dataset[precip_var_name].units)
+                    "Unsupported precipitation units: {var}".format(
+                        var=dataset[precip_var_name].units
+                    )
                 )
     if "var_name_temp" in keyword_arguments:
         temp_var_name = keyword_arguments["var_name_temp"]
@@ -530,7 +532,9 @@ def _compute_write_index(keyword_arguments):
                 )
             else:
                 raise ValueError(
-                    "Unsupported temperature units: {var}".format(var=dataset[temp_var_name].units)
+                    "Unsupported temperature units: {var}".format(
+                        var=dataset[temp_var_name].units
+                    )
                 )
 
     # get the data arrays we'll use later in the index computations

--- a/scripts/process_grid.py
+++ b/scripts/process_grid.py
@@ -1,6 +1,6 @@
 import argparse
 from collections import Counter
-from datetime import datetime, date
+from datetime import datetime
 import logging
 import multiprocessing
 import os


### PR DESCRIPTION
Now converting into 366-day calendar for use during the computation of indices for daily values, converting back into Gregorian for output.

Resolves #270 