### PR TITLE
Change _pearson_fit logical relation from `and` to `or`

### DIFF
--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -413,7 +413,7 @@ def _pearson_fit(
         # TODO ask Richard Heim why the use of this floor value, matching
         #  that used for the trace amount?
         nans_mask = np.isnan(values)
-        values[np.logical_and(minimums_mask, nans_mask)] = 0.0005
+        values[np.logical_or(minimums_mask, nans_mask)] = 0.0005
 
         # account for negative skew
         skew_mask = skew < 0.0


### PR DESCRIPTION
One way _pearson_fit sanitizes the values it will be working
with is by setting any null or miniscule values to a predetermined
minimum value.

However, it checks for whether a value is null or miniscule by
only looking for values that are *both* null and miniscule. Change
this so that the logic works as intended.

See #421