### PR TITLE
comparing longitudes and latitudes with tolerance

### DIFF
--- a/src/climate_indices/__main__.py
+++ b/src/climate_indices/__main__.py
@@ -15,7 +15,8 @@ from climate_indices import compute, indices, utils
 
 # the number of worker processes we'll use for process pools
 _NUMBER_OF_WORKER_PROCESSES = multiprocessing.cpu_count() - 1
-
+# threshold absolute tolerance parameter np.allclose
+ATOL_THRESH = 0.01
 # shared memory array dictionary keys
 _KEY_ARRAY = "array"
 _KEY_SHAPE = "shape"
@@ -215,11 +216,11 @@ def _validate_args(args):
                         raise ValueError(msg)
 
                     # verify that the coordinate variables match with those of the precipitation dataset
-                    if not np.array_equal(lats_precip, dataset_pet["lat"][:]):
+                    if not np.allclose(lats_precip, dataset_pet["lat"][:], atol=ATOL_THRESH):
                         msg = "Precipitation and PET variables contain non-matching latitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
-                    elif not np.array_equal(lons_precip, dataset_pet["lon"][:]):
+                    elif not np.allclose(lons_precip, dataset_pet["lon"][:], atol=ATOL_THRESH):
                         msg = "Precipitation and PET variables contain non-matching longitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
@@ -297,11 +298,11 @@ def _validate_args(args):
                         raise ValueError(msg)
 
                     # verify that the coordinate variables match with those of the precipitation dataset
-                    if not np.array_equal(lats_precip, dataset_temp["lat"][:]):
+                    if not np.allclose(lats_precip, dataset_temp["lat"][:], atol=ATOL_THRESH):
                         msg = "Precipitation and temperature variables contain non-matching latitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
-                    elif not np.array_equal(lons_precip, dataset_temp["lon"][:]):
+                    elif not np.allclose(lons_precip, dataset_temp["lon"][:], atol=ATOL_THRESH):
                         msg = "Precipitation and temperature variables contain non-matching longitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
@@ -375,11 +376,11 @@ def _validate_args(args):
                         raise ValueError(msg)
 
                     # verify that the coordinate variables match with those of the precipitation dataset
-                    if not np.allclose(lats_precip, dataset_awc["lat"][:], atol=0.01):
+                    if not np.allclose(lats_precip, dataset_awc["lat"][:], atol=ATOL_THRESH):
                         msg = "Precipitation and AWC variables contain non-matching latitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
-                    elif not np.allclose(lons_precip, dataset_awc["lon"][:], atol=0.01):
+                    elif not np.allclose(lons_precip, dataset_awc["lon"][:], atol=ATOL_THRESH):
                         msg = "Precipitation and AWC variables contain non-matching longitudes"
                         _logger.error(msg)
                         raise ValueError(msg)

--- a/src/climate_indices/__main__.py
+++ b/src/climate_indices/__main__.py
@@ -15,8 +15,6 @@ from climate_indices import compute, indices, utils
 
 # the number of worker processes we'll use for process pools
 _NUMBER_OF_WORKER_PROCESSES = multiprocessing.cpu_count() - 1
-# threshold absolute tolerance parameter np.allclose
-ATOL_THRESH = 0.01
 # shared memory array dictionary keys
 _KEY_ARRAY = "array"
 _KEY_SHAPE = "shape"
@@ -90,6 +88,11 @@ def _validate_args(args):
     expected_dimensions_divisions_awc = [("time", "division"),
                                          ("division", "time"),
                                          ("division")]
+
+    # dynamic threshold absolute tolerance parameter np.allclose
+    # derived from (smallest) grid size along dimension dim
+    def get_tolerance(dim):
+        return np.diff(dim).min() / 10
 
     # all indices except PET require a precipitation file
     if args.index != "pet":
@@ -216,11 +219,12 @@ def _validate_args(args):
                         raise ValueError(msg)
 
                     # verify that the coordinate variables match with those of the precipitation dataset
-                    if not np.allclose(lats_precip, dataset_pet["lat"][:], atol=ATOL_THRESH):
+                    if not np.allclose(lats_precip, dataset_pet["lat"][:], atol=get_
+                    (lats_precip)):
                         msg = "Precipitation and PET variables contain non-matching latitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
-                    elif not np.allclose(lons_precip, dataset_pet["lon"][:], atol=ATOL_THRESH):
+                    elif not np.allclose(lons_precip, dataset_pet["lon"][:], atol=get_tolerance(lons_precip)):
                         msg = "Precipitation and PET variables contain non-matching longitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
@@ -298,11 +302,11 @@ def _validate_args(args):
                         raise ValueError(msg)
 
                     # verify that the coordinate variables match with those of the precipitation dataset
-                    if not np.allclose(lats_precip, dataset_temp["lat"][:], atol=ATOL_THRESH):
+                    if not np.allclose(lats_precip, dataset_temp["lat"][:], atol=get_tolerance(lats_precip)):
                         msg = "Precipitation and temperature variables contain non-matching latitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
-                    elif not np.allclose(lons_precip, dataset_temp["lon"][:], atol=ATOL_THRESH):
+                    elif not np.allclose(lons_precip, dataset_temp["lon"][:], atol=get_tolerance(lons_precip)):
                         msg = "Precipitation and temperature variables contain non-matching longitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
@@ -376,11 +380,11 @@ def _validate_args(args):
                         raise ValueError(msg)
 
                     # verify that the coordinate variables match with those of the precipitation dataset
-                    if not np.allclose(lats_precip, dataset_awc["lat"][:], atol=ATOL_THRESH):
+                    if not np.allclose(lats_precip, dataset_awc["lat"][:], atol=get_tolerance(lats_precip)):
                         msg = "Precipitation and AWC variables contain non-matching latitudes"
                         _logger.error(msg)
                         raise ValueError(msg)
-                    elif not np.allclose(lons_precip, dataset_awc["lon"][:], atol=ATOL_THRESH):
+                    elif not np.allclose(lons_precip, dataset_awc["lon"][:], atol=get_tolerance(lons_precip)):
                         msg = "Precipitation and AWC variables contain non-matching longitudes"
                         _logger.error(msg)
                         raise ValueError(msg)

--- a/src/climate_indices/__main__.py
+++ b/src/climate_indices/__main__.py
@@ -219,8 +219,7 @@ def _validate_args(args):
                         raise ValueError(msg)
 
                     # verify that the coordinate variables match with those of the precipitation dataset
-                    if not np.allclose(lats_precip, dataset_pet["lat"][:], atol=get_
-                    (lats_precip)):
+                    if not np.allclose(lats_precip, dataset_pet["lat"][:], atol=get_tolerance(lats_precip)):
                         msg = "Precipitation and PET variables contain non-matching latitudes"
                         _logger.error(msg)
                         raise ValueError(msg)


### PR DESCRIPTION
This is to close #465. The remaining `np.array_equal`s are replaced by `np.allclose`s where longitudes and latitudes are compared but no divisions (`input_type == InputType.divisions`). The fixed absolute tolerance of 0.01 is replaced by a dynamic tolerance derived from the (smallest) grid size.