### PR TITLE
Version 1.0.12 added to PyPI

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,17 +121,6 @@ file in the dependencies section, then we can rebuild the requirements.txt file 
 ``$ python -m piptools compile -o requirements.txt pyproject.toml``
 
 
-NCO
-^^^^
-
-NetCDF Operators is a requirement and must be installed for utilization of this package.
-Instructions for installation on various platforms is available `here <http://nco.sourceforge.net#Executables//>`_.
-If using an Anaconda environment as advised above then it's as simple as running
-the following command within the activated conda environment:
-
-``$ conda install -c conda-forge nco``
-
-
 Indices Processing
 ----------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ classifiers = [
 ]
 dependencies = [
     'dask',
-#    'nco',
-#    'netCDF4',
     'numba',
     'scipy',
     'xarray',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'climate_indices'
-version = '1.0.11'
+version = '1.0.12'
 readme = 'README.md'
 requires-python = '>=3.7'
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements.txt pyproject.toml
 #
-cftime==1.6.2
-    # via netcdf4
 cloudpickle==2.2.0
     # via dask
 dask==2022.2.0
@@ -20,16 +18,10 @@ llvmlite==0.39.1
     # via numba
 locket==1.0.0
     # via partd
-nco==1.0.0
-    # via climate-indices (pyproject.toml)
-netcdf4==1.6.2
-    # via climate-indices (pyproject.toml)
 numba==0.56.4
     # via climate-indices (pyproject.toml)
 numpy==1.21.6
     # via
-    #   cftime
-    #   netcdf4
     #   numba
     #   pandas
     #   scipy


### PR DESCRIPTION
I followed this recipe for adding the latest code to PyPI:

$ cd $CLIMATE_INDICES_ROOT
$ rm -rf dist
$ python -m build --wheel
$ twine check dist/*
$ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
$ twine upload dist/*