### PR TITLE
Relax package dependency requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,16 +44,16 @@ classifiers = [
 packages = [{include = 'climate_indices', from = 'src'}]
 
 [tool.poetry.dependencies]
-cftime = '1.6.2'
-dask = '2022.2.0'
-h5netcdf = '1.1.0'
+cftime = '>=1.6.2'
+dask = '>=2022.2.0'
+h5netcdf = '>=1.1.0'
 python = '>=3.8,<3.12'
-scipy = '~=1.10.0'
-xarray = '2023.1.0'
+scipy = '>=1.10.0'
+xarray = '>=2023.1.0'
 
 [tool.poetry.dev-dependencies]
 pytest = '*'
-toml = '0.10.2'
+toml = '>=0.10.2'
 
 [tool.poetry.group.dev.dependencies]
 sphinx-autodoc-typehints = "^1.23.3"

--- a/src/climate_indices/__spi__.py
+++ b/src/climate_indices/__spi__.py
@@ -575,7 +575,7 @@ def _compute_write_index(keyword_arguments):
             fitting_shape = [len(x) for x in ds_fitting.coords.values()]
             for var in _FITTING_VARIABLES:
                 da_fitting = xr.DataArray(
-                    data=np.full(shape=fitting_shape, fill_value=np.NaN),
+                    data=np.full(shape=fitting_shape, fill_value=np.nan),
                     # Assumes it is in the proper order.
                     coords=ds_fitting.coords,
                     name=fitting_var_names[var],

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -154,7 +154,7 @@ def sum_to_scale(
     sliding_sums = np.convolve(values, np.ones(scale), mode="valid")
 
     # pad the first (n - 1) elements of the array with NaN values
-    return np.hstack(([np.NaN] * (scale - 1), sliding_sums))
+    return np.hstack(([np.nan] * (scale - 1), sliding_sums))
 
     # BELOW FOR dask/xarray DataArray integration
     # # pad the values array with (scale - 1) NaNs
@@ -218,7 +218,7 @@ def _probability_of_zero(
 
         else:
             # fill with NaN
-            probabilities_of_zero[time_step_index] = np.NaN
+            probabilities_of_zero[time_step_index] = np.nan
 
     return probabilities_of_zero
 
@@ -674,15 +674,15 @@ def gamma_parameters(
             shape = (366,)
         else:
             raise ValueError("Unsupported periodicity: {periodicity}".format(periodicity=periodicity))
-        alphas = np.full(shape=shape, fill_value=np.NaN)
-        betas = np.full(shape=shape, fill_value=np.NaN)
+        alphas = np.full(shape=shape, fill_value=np.nan)
+        betas = np.full(shape=shape, fill_value=np.nan)
         return alphas, betas
 
     # validate (and possibly reshape) the input array
     values = _validate_array(values, periodicity)
 
     # replace zeros with NaNs
-    values[values == 0] = np.NaN
+    values[values == 0] = np.nan
 
     # determine the end year of the values array
     data_end_year = data_start_year + values.shape[0]
@@ -805,7 +805,7 @@ def transform_fitted_gamma(
     probabilities_of_zero = zeros / values.shape[0]
 
     # replace zeros with NaNs
-    values[values == 0] = np.NaN
+    values[values == 0] = np.nan
 
     # compute fitting parameters if none were provided
     if (alphas is None) or (betas is None):

--- a/src/climate_indices/eto.py
+++ b/src/climate_indices/eto.py
@@ -266,7 +266,7 @@ def eto_thornthwaite(
     mean_daylight_hours_leap = np.array(_monthly_mean_daylight_hours(latitude_radians, True))
 
     # allocate the PET array we'll fill
-    pet = np.full(monthly_temps_celsius.shape, np.NaN)
+    pet = np.full(monthly_temps_celsius.shape, np.nan)
     for year in range(monthly_temps_celsius.shape[0]):
         if calendar.isleap(data_start_year + year):
             month_days = _MONTH_DAYS_LEAP
@@ -331,7 +331,7 @@ def eto_hargreaves(
     latitude = math.radians(latitude_degrees)
 
     # allocate the PET array we'll fill
-    pet = np.full(daily_tmean_celsius.shape, np.NaN)
+    pet = np.full(daily_tmean_celsius.shape, np.nan)
     for day_of_year in range(1, daily_tmean_celsius.shape[1] + 1):
         # calculate the angle of solar declination and sunset hour angle
         solar_declination = _solar_declination(day_of_year)

--- a/src/climate_indices/utils.py
+++ b/src/climate_indices/utils.py
@@ -226,7 +226,7 @@ def reshape_to_2d(
     final_year_values = shape[0] % second_axis_length
     if final_year_values > 0:
         pads = second_axis_length - final_year_values
-        values = np.pad(values, pad_width=(0, pads), mode="constant", constant_values=np.NaN)
+        values = np.pad(values, pad_width=(0, pads), mode="constant", constant_values=np.nan)
 
     # we should have an ordinal number of years now
     # (ordinally divisible by second_axis_length)
@@ -344,7 +344,7 @@ def transform_to_366day(
 
     # allocate the new array for 366 daily values per year,
     # including a faux Feb 29 for non-leap years
-    all_leap = np.full((total_years * 366,), np.NaN)
+    all_leap = np.full((total_years * 366,), np.nan)
 
     # index of the first day of the year within the original and all_leap arrays
     original_index = 0
@@ -384,7 +384,7 @@ def transform_to_366day(
                             difference,
                         ),
                         mode="constant",
-                        constant_values=np.NaN,
+                        constant_values=np.nan,
                     )
                 elif difference != 0:
                     raise ValueError("Incompatible shapes")
@@ -457,7 +457,7 @@ def transform_to_gregorian(
 
     # allocate the new array we'll write daily values into,
     # including a faux Feb 29 for non-leap years
-    gregorian = np.full((days_actual,), np.NaN)
+    gregorian = np.full((days_actual,), np.nan)
 
     # index of the first day of the year within the original and gregorian arrays
     original_index = 0


### PR DESCRIPTION
* Relax dependency requirements to allow newer versions.
* Gain numpy 2.x compatibility by fixing np.NaN to np.nan