### PR TITLE
Enumeration comparisons changed from usage of `is` to `==`

### DIFF
--- a/src/climate_indices/indices.py
+++ b/src/climate_indices/indices.py
@@ -138,9 +138,9 @@ def spi(
     values = compute.sum_to_scale(values, scale)
 
     # reshape precipitation values to (years, 12) for monthly, or to (years, 366) for daily
-    if (periodicity == compute.Periodicity.monthly) or (periodicity == "monthly"):
-        values = utils.reshape_to_2d(values, 12)
-    elif (periodicity == compute.Periodicity.daily) or (periodicity == "daily"):
+    if periodicity == compute.Periodicity.monthly:
+            values = utils.reshape_to_2d(values, 12)
+    elif periodicity == compute.Periodicity.daily:
         values = utils.reshape_to_2d(values, 366)
     else:
         raise ValueError(f"Invalid periodicity argument: '{periodicity}'")

--- a/src/climate_indices/indices.py
+++ b/src/climate_indices/indices.py
@@ -397,9 +397,9 @@ def percentage_of_normal(
 
     # if doing monthly then we'll use 12 periods, corresponding to calendar
     # months, if daily assume years w/366 days
-    if periodicity is compute.Periodicity.monthly:
+    if periodicity == compute.Periodicity.monthly:
         periodicity = 12
-    elif periodicity is compute.Periodicity.daily:
+    elif periodicity == compute.Periodicity.daily:
         periodicity = 366
     else:
         message = f"Invalid periodicity argument: '{periodicity}'"

--- a/src/climate_indices/indices.py
+++ b/src/climate_indices/indices.py
@@ -137,16 +137,15 @@ def spi(
     # by the specified number of time steps
     values = compute.sum_to_scale(values, scale)
 
-    # reshape precipitation values to (years, 12) for monthly,
-    # or to (years, 366) for daily
-    if periodicity is compute.Periodicity.monthly:
+    # reshape precipitation values to (years, 12) for monthly, or to (years, 366) for daily
+    if (periodicity == compute.Periodicity.monthly) or (periodicity == "monthly"):
         values = utils.reshape_to_2d(values, 12)
-    elif periodicity is compute.Periodicity.daily:
+    elif (periodicity == compute.Periodicity.daily) or (periodicity == "daily"):
         values = utils.reshape_to_2d(values, 366)
     else:
-        raise ValueError(f"Invalid periodicity argument: {periodicity}")
+        raise ValueError(f"Invalid periodicity argument: '{periodicity}'")
 
-    if distribution is Distribution.gamma:
+    if distribution == Distribution.gamma:
         # get (optional) fitting parameters if provided
         if fitting_params is not None:
             alphas = fitting_params["alpha"]
@@ -166,7 +165,7 @@ def spi(
             alphas,
             betas,
         )
-    elif distribution is Distribution.pearson:
+    elif distribution == Distribution.pearson:
         # get (optional) fitting parameters if provided
         if fitting_params is not None:
             probabilities_of_zero = fitting_params["prob_zero"]
@@ -194,7 +193,7 @@ def spi(
         )
 
     else:
-        message = f"Unsupported distribution argument: {distribution}"
+        message = f"Unsupported distribution argument: '{distribution}'"
         _logger.error(message)
         raise ValueError(message)
 


### PR DESCRIPTION
Addressing #558 we've changed usages of `is` to `==` for comparisons of Periodicity and Distribution type arguments. This seems to fix that issue and maybe has something to do with how `dask` handles enumerated types when passed as arguments, maybe Enum class types don't fit well compared to strings, etc.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix enumeration comparisons by replacing 'is' with '==' for Periodicity and Distribution types to address compatibility issues, potentially related to how 'dask' handles enumerated types.

Bug Fixes:
- Fix enumeration comparisons by replacing the use of 'is' with '==' for Periodicity and Distribution type arguments to ensure correct behavior.

<!-- Generated by sourcery-ai[bot]: end summary -->