### PR TITLE
Changes for Python 3.13 support

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -23,13 +23,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip poetry
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
 
       - name: Set up project
-        run: |
-          cd $GITHUB_WORKSPACE
-          poetry install
+        run: uv sync --dev
 
       - name: Run unit tests
-        run: poetry run pytest
+        run: uv run pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,7 @@ Follow these rules and you should succeed without a problem.
 ### Run the tests
 Before you submit a pull request, please run the entire test suite via:
 
-`$ export NUMBA_DISABLE_JIT=1`
-`$ python setup.py test`
-`$ unset  NUMBA_DISABLE_JIT`
+`$ uv run pytest`
 
 The first thing the core committers will do is run this command. Any pull request that fails this test suite will be rejected.
 
@@ -114,7 +112,7 @@ First we pull the code into a local branch:
 
 Then we run the tests:
 
-`$ python -m unittest tests/test_*.py`
+`$ uv run pytest`
 
 We finish with a merge and push to GitHub:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN uv sync --frozen --no-dev
 FROM python:3.11-slim
 
 # Install runtime dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    build-essential \
     libhdf5-dev \
     libnetcdf-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as builder
+FROM python:3.11-slim AS builder
 
 LABEL authors="monocongo@gmail.com"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM python:3.11-slim as builder
+
+LABEL authors="monocongo@gmail.com"
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies
+RUN uv sync --frozen --no-dev
+
+# Production stage
+FROM python:3.11-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libhdf5-dev \
+    libnetcdf-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy uv and virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /bin/uv /bin/uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy source code
+COPY src/ ./src/
+COPY pyproject.toml ./
+
+# Create non-root user
+RUN useradd --create-home --shell /bin/bash climate
+USER climate
+
+# Set environment variables
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH="/app/src:$PYTHONPATH"
+
+# Set entrypoint
+ENTRYPOINT ["python", "-m", "climate_indices"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,14 +64,17 @@ Quick Start
    ::
 
     # create and activate a Python virtual environment with conda
-    conda create -n myvenv poetry pytest
+    conda create -n myvenv python=3.10
     conda activate myvenv
 
+    # install uv
+    pip install uv
+
     # install the package
-    python -m poetry install
+    uv sync --dev
 
     # optionally run the unit tests suite
-    python -m poetry run pytest
+    uv run pytest
 
 
 Installation
@@ -81,22 +84,22 @@ From PyPI
 
 Install directly from PyPI::
 
-    python -m pip install climate-indices
+    uv add climate-indices
 
 From source
 ^^^^^^^^^^^^^^
 
-In order to build and install the package from source we need to first install `poetry <https://python-poetry.org/>`__::
+In order to build and install the package from source we need to first install `uv <https://docs.astral.sh/uv/>`__::
 
-    python -m pip install poetry
+    pip install uv
 
 Then install the package from source::
 
-   python -m poetry install
+   uv sync --dev
 
 Next (optional) run the unit test suite to validate the installation::
 
-    python -m pytest tests
+    uv run pytest
 
 the above should display output similar to this::
 
@@ -104,12 +107,10 @@ the above should display output similar to this::
 
 Finally, show the package installed into the environment::
 
-   conda list climate-indices
+   uv list | grep climate-indices
 
-   # packages in environment at /Users/jadams/miniconda3/envs/climate381:
-   #
-   # Name                    Version                   Build  Channel
-   climate-indices           1.0.16                   pypi_0    pypi
+   # climate-indices v2.1.0 (editable)
+   #     + climate-indices==2.1.0 (from file:///path/to/climate_indices)
 
 
 

--- a/notebooks/concurrent_shared_memory_example.ipynb
+++ b/notebooks/concurrent_shared_memory_example.ipynb
@@ -8,11 +8,8 @@
    "source": [
     "import concurrent.futures\n",
     "from multiprocessing import cpu_count, shared_memory\n",
-    "import sys\n",
-    "from typing import Dict\n",
     "\n",
-    "import numpy as np\n",
-    "import xarray as xr"
+    "import numpy as np"
    ]
   },
   {
@@ -59,7 +56,7 @@
    "outputs": [],
    "source": [
     "def shm_add_average(\n",
-    "    arguments: Dict,\n",
+    "    arguments: dict,\n",
     "):\n",
     "    existing_shm_input = shared_memory.SharedMemory(name=arguments[\"shm_name_input\"])\n",
     "    shm_ary_input = np.ndarray(\n",

--- a/notebooks/generate_fitting_parameters_nclimgrid.ipynb
+++ b/notebooks/generate_fitting_parameters_nclimgrid.ipynb
@@ -7,16 +7,14 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "from typing import Dict\n",
     "\n",
-    "import matplotlib\n",
     "import numpy as np\n",
     "import xarray as xr\n",
     "\n",
     "climate_indices_home_path = \"/home/james/git/climate_indices\"\n",
     "if climate_indices_home_path not in sys.path:\n",
     "    sys.path.insert(climate_indices_home_path)\n",
-    "from climate_indices import compute, indices, utils\n",
+    "from climate_indices import compute, indices\n",
     "\n",
     "%matplotlib inline"
    ]
@@ -115,7 +113,7 @@
    "source": [
     "def compute_gammas(\n",
     "    da_precip: xr.DataArray,\n",
-    "    gamma_coords: Dict,\n",
+    "    gamma_coords: dict,\n",
     "    scale: int,\n",
     "    calibration_year_initial,\n",
     "    calibration_year_final,\n",
@@ -139,9 +137,7 @@
     "            values = da_precip[lat_index, lon_index]\n",
     "\n",
     "            # skip over this grid cell if all NaN values\n",
-    "            if (np.ma.is_masked(values) and values.mask.all()) or np.all(\n",
-    "                np.isnan(values)\n",
-    "            ):\n",
+    "            if (np.ma.is_masked(values) and values.mask.all()) or np.all(np.isnan(values)):\n",
     "                continue\n",
     "\n",
     "            # convolve to scale\n",
@@ -220,9 +216,7 @@
     "            values = da_precip[lat_index, lon_index]\n",
     "\n",
     "            # skip over this grid cell if all NaN values\n",
-    "            if (np.ma.is_masked(values) and values.mask.all()) or np.all(\n",
-    "                np.isnan(values)\n",
-    "            ):\n",
+    "            if (np.ma.is_masked(values) and values.mask.all()) or np.all(np.isnan(values)):\n",
     "                continue\n",
     "\n",
     "            gamma_parameters = {\n",
@@ -289,9 +283,7 @@
     "    \"geospatial_lat_units\",\n",
     "    \"geospatial_lon_units\",\n",
     "]\n",
-    "global_attrs = {\n",
-    "    key: value for (key, value) in ds_prcp.attrs.items() if key in attrs_to_copy\n",
-    "}"
+    "global_attrs = {key: value for (key, value) in ds_prcp.attrs.items() if key in attrs_to_copy}"
    ]
   },
   {
@@ -437,9 +429,7 @@
     "            values = da_precip[lat_index, lon_index]\n",
     "\n",
     "            # skip over this grid cell if all NaN values\n",
-    "            if (np.ma.is_masked(values) and values.mask.all()) or np.all(\n",
-    "                np.isnan(values)\n",
-    "            ):\n",
+    "            if (np.ma.is_masked(values) and values.mask.all()) or np.all(np.isnan(values)):\n",
     "                continue\n",
     "\n",
     "            # compute the SPI\n",

--- a/notebooks/spi_simple.ipynb
+++ b/notebooks/spi_simple.ipynb
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from climate_indices.compute import scale_values, Periodicity"
+    "from climate_indices.compute import Periodicity, scale_values"
    ]
   },
   {
@@ -328,9 +328,7 @@
     "# do it \"by hand\" by looping over each lat/lon point\n",
     "for lat_index in range(len(da_one_more_lo_looper[\"lat\"])):\n",
     "    for lon_index in range(len(da_one_more_lo_looper[\"lon\"])):\n",
-    "        da_one_more_lo_looper[lat_index, lon_index] = add_one(\n",
-    "            da_one_more_lo_looper[lat_index, lon_index]\n",
-    "        )"
+    "        da_one_more_lo_looper[lat_index, lon_index] = add_one(da_one_more_lo_looper[lat_index, lon_index])"
    ]
   },
   {
@@ -363,9 +361,7 @@
     "# do it \"by hand\" by looping over each lat/lon point\n",
     "for lat_index in range(len(da_one_more_hi_looper[\"lat\"])):\n",
     "    for lon_index in range(len(da_one_more_hi_looper[\"lon\"])):\n",
-    "        da_one_more_hi_looper[lat_index, lon_index] = add_one(\n",
-    "            da_one_more_hi_looper[lat_index, lon_index]\n",
-    "        )"
+    "        da_one_more_hi_looper[lat_index, lon_index] = add_one(da_one_more_hi_looper[lat_index, lon_index])"
    ]
   },
   {
@@ -426,10 +422,7 @@
     "    if len(shape) == 2:\n",
     "        values = values.flatten()\n",
     "    elif len(shape) != 1:\n",
-    "        message = (\n",
-    "            \"Invalid shape of input array: {shape}\".format(shape=shape)\n",
-    "            + \" -- only 1-D and 2-D arrays are supported\"\n",
-    "        )\n",
+    "        message = f\"Invalid shape of input array: {shape}\" + \" -- only 1-D and 2-D arrays are supported\"\n",
     "        _logger.error(message)\n",
     "        raise ValueError(message)\n",
     "\n",
@@ -484,9 +477,7 @@
     "        )\n",
     "\n",
     "    else:\n",
-    "        message = \"Unsupported distribution argument: \" + \"{dist}\".format(\n",
-    "            dist=distribution\n",
-    "        )\n",
+    "        message = \"Unsupported distribution argument: \" + f\"{distribution}\"\n",
     "        _logger.error(message)\n",
     "        raise ValueError(message)\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ exclude = '''
 
 [tool.poetry]
 name = 'climate_indices'
-version = '2.0.1'
+version = '2.0.2'
 description = 'Reference implementations of various climate indices typically used for drought monitoring'
 authors = ['James Adams <monocongo@gmail.com>']
 readme = 'README.md'
@@ -33,27 +33,27 @@ classifiers = [
      'Intended Audience :: Education',
      'Intended Audience :: Science/Research',
      'License :: OSI Approved :: BSD License',
-     'Programming Language :: Python :: 3.8',
-     'Programming Language :: Python :: 3.9',
      'Programming Language :: Python :: 3.10',
      'Programming Language :: Python :: 3.11',
+     'Programming Language :: Python :: 3.12',
+     'Programming Language :: Python :: 3.13',
      'Topic :: Software Development :: Libraries :: Python Modules',
-     'Topic :: Scientific/Engineering :: Atmospheric Science',
-     'Topic :: Scientific/Engineering :: Physics'
+     'Topic :: Scientific/Engineering :: Climate Science',
 ]
 packages = [{include = 'climate_indices', from = 'src'}]
 
 [tool.poetry.dependencies]
 # only Python and scipy are required for the base library code
-python = '>=3.8,<3.12'
-scipy = '1.10.1'
+python = '>=3.10,<3.14'
+scipy = '>=1.14.1'
 # remaining dependencies are required for the CLI (console) scripts
 cftime = '>=1.6.4'
-dask = '>=2023.5.0'
-h5netcdf = '>=1.1.0'
-xarray = '>=2023.1.0'
+dask = '>=2024.12.0'
+h5netcdf = '>=1.4.0'
+xarray = '>=2024.11.0'
 
 [tool.poetry.dev-dependencies]
+coverage = '^7.6.9'
 pytest = '8.3.3'
 toml = '>=0.10.2'
 
@@ -68,3 +68,72 @@ spi = 'climate_indices.__spi__:main'
 filterwarnings = [
     'ignore::FutureWarning',
 ]
+
+## ==========================   below for conversion to uv instead of poetry  ==========================
+#[project]
+#    authors = [
+#        {name = "James Adams", email = "monocongo@gmail.com"},
+#    ]
+#    requires-python = ">=3.10,<3.14"
+#    dependencies = [
+#        "scipy>=1.14.1",
+#        "cftime",
+#        "dask",
+#        "h5py",
+#        "xarray",
+#    ]
+#    name = "climate_indices"
+#    version = "2.0.2"
+#    description = "Reference implementations of various climate indices typically used for drought monitoring"
+#    readme = "README.md"
+#    classifiers = [
+#        "Development Status :: 5 - Production/Stable",
+#        "Intended Audience :: Developers",
+#        "Intended Audience :: Education",
+#        "Intended Audience :: Science/Research",
+#        "License :: OSI Approved :: BSD License",
+#        "Programming Language :: Python :: 3.10",
+#        "Programming Language :: Python :: 3.11",
+#        "Programming Language :: Python :: 3.12",
+#        "Programming Language :: Python :: 3.13",
+#        "Topic :: Software Development :: Libraries :: Python Modules",
+#        "Topic :: Scientific/Engineering :: Climate Science",
+#    ]
+#
+#[dependency-groups]
+#    dev = [
+#        "sphinx-autodoc-typehints==2.0.1",
+#        "pytest==8.3.3",
+#        "toml>=0.10.2",
+#    ]
+#
+#[project.urls]
+#    'Homepage' = 'https://github.com/monocongo/climate_indices'
+#    'Bug Tracker' = 'https://github.com/monocongo/climate_indices/issues'
+#
+#[project.scripts]
+#    process_climate_indices = "climate_indices.__main__:main"
+#    spi = "climate_indices.__spi__:main"
+#
+#[tool.black]
+#line-length = 120
+#target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+#include = '\.pyi?$'
+#exclude = '''
+#/(
+#    \.git
+#  | \.mypy_cache
+#  | \.tox
+#  | \.venv
+#  | build
+#  | dist
+#)/
+#'''
+#
+#[tool.pytest.ini_options]
+#filterwarnings = [
+#    'ignore::FutureWarning',
+#]
+#
+#[tool.pdm.build]
+#includes = ["src/climate_indices"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,12 @@
 [build-system]
-requires = ['poetry-core>=1.0.0']
-build-backend = 'poetry.core.masonry.api'
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[project.urls]
-'Homepage' = 'https://github.com/monocongo/climate_indices'
-'Bug Tracker' = 'https://github.com/monocongo/climate_indices/issues'
-
-[tool.black]
-line-length = 120
-target-version = ['py39', 'py310', 'py311']
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-)/
-'''
-
-[tool.poetry]
-name = 'climate_indices'
-version = '2.0.2'
+[project]
+name = "climate_indices"
+version = '2.1.0'
 description = 'Reference implementations of various climate indices typically used for drought monitoring'
-authors = ['James Adams <monocongo@gmail.com>']
+authors = [{name = "James Adams", email = "monocongo@gmail.com"}]
 readme = 'README.md'
 classifiers = [
      'Development Status :: 5 - Production/Stable',
@@ -38,102 +19,112 @@ classifiers = [
      'Programming Language :: Python :: 3.12',
      'Programming Language :: Python :: 3.13',
      'Topic :: Software Development :: Libraries :: Python Modules',
-     'Topic :: Scientific/Engineering :: Climate Science',
+     'Topic :: Scientific/Engineering :: Atmospheric Science',
 ]
 packages = [{include = 'climate_indices', from = 'src'}]
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "scipy>=1.14.1",
+    # remaining dependencies are required for the CLI (console) scripts
+    "cftime>=1.6.4",
+    "dask>=2024.12.0",
+    "h5netcdf>=1.4.0",
+    "xarray>=2024.11.0",
+]
+[project.optional-dependencies]
+dev = [
+    "coverage>=7.6.9",
+    "pytest>=8.3.3",
+    "pytest-cov>=2.0",
+    "ruff>=0.1.0",
+    "toml>=0.10.2",
+    "sphinx-autodoc-typehints>=2.0.1",
+]
+docs = [
+    "sphinx>=4.0",
+    "sphinx-rtd-theme>=1.0",
+]
 
-[tool.poetry.dependencies]
-# only Python and scipy are required for the base library code
-python = '>=3.10,<3.14'
-scipy = '>=1.14.1'
-# remaining dependencies are required for the CLI (console) scripts
-cftime = '>=1.6.4'
-dask = '>=2024.12.0'
-h5netcdf = '>=1.4.0'
-xarray = '>=2024.11.0'
+[project.scripts]
+climate_indices = "climate_indices.__main__:main"
+process_climate_indices = "climate_indices.__main__:main"
+spi = "climate_indices.__spi__:main"
 
-[tool.poetry.dev-dependencies]
-coverage = '^7.6.9'
-pytest = '8.3.3'
-toml = '>=0.10.2'
+[project.urls]
+'Homepage' = 'https://github.com/monocongo/climate_indices'
+'Bug Tracker' = 'https://github.com/monocongo/climate_indices/issues'
 
-[tool.poetry.group.dev.dependencies]
-sphinx-autodoc-typehints = '2.0.1'
+[tool.black]
+line-length = 120
+target-version = ['py310', 'py311', 'py312', 'py313']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
 
-[tool.poetry.scripts]
-process_climate_indices = 'climate_indices.__main__:main'
-spi = 'climate_indices.__spi__:main'
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
+]
+ignore = [
+    "E501",  # line too long, handled by black
+    "B008",  # do not perform function calls in argument defaults
+]
+per-file-ignores = {"__init__.py" = ["F401"], "tests/**/*" = ["B011"]}
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+
+[[tool.mypy.overrides]]
+module = [
+    "scipy.*",
+    "netCDF4.*",
+    "xarray.*",
+    "dask.*",
+]
+ignore_missing_imports = true
+
 
 [tool.pytest.ini_options]
 filterwarnings = [
     'ignore::FutureWarning',
 ]
 
-## ==========================   below for conversion to uv instead of poetry  ==========================
-#[project]
-#    authors = [
-#        {name = "James Adams", email = "monocongo@gmail.com"},
-#    ]
-#    requires-python = ">=3.10,<3.14"
-#    dependencies = [
-#        "scipy>=1.14.1",
-#        "cftime",
-#        "dask",
-#        "h5py",
-#        "xarray",
-#    ]
-#    name = "climate_indices"
-#    version = "2.0.2"
-#    description = "Reference implementations of various climate indices typically used for drought monitoring"
-#    readme = "README.md"
-#    classifiers = [
-#        "Development Status :: 5 - Production/Stable",
-#        "Intended Audience :: Developers",
-#        "Intended Audience :: Education",
-#        "Intended Audience :: Science/Research",
-#        "License :: OSI Approved :: BSD License",
-#        "Programming Language :: Python :: 3.10",
-#        "Programming Language :: Python :: 3.11",
-#        "Programming Language :: Python :: 3.12",
-#        "Programming Language :: Python :: 3.13",
-#        "Topic :: Software Development :: Libraries :: Python Modules",
-#        "Topic :: Scientific/Engineering :: Climate Science",
-#    ]
-#
-#[dependency-groups]
-#    dev = [
-#        "sphinx-autodoc-typehints==2.0.1",
-#        "pytest==8.3.3",
-#        "toml>=0.10.2",
-#    ]
-#
-#[project.urls]
-#    'Homepage' = 'https://github.com/monocongo/climate_indices'
-#    'Bug Tracker' = 'https://github.com/monocongo/climate_indices/issues'
-#
-#[project.scripts]
-#    process_climate_indices = "climate_indices.__main__:main"
-#    spi = "climate_indices.__spi__:main"
-#
-#[tool.black]
-#line-length = 120
-#target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
-#include = '\.pyi?$'
-#exclude = '''
-#/(
-#    \.git
-#  | \.mypy_cache
-#  | \.tox
-#  | \.venv
-#  | build
-#  | dist
-#)/
-#'''
-#
-#[tool.pytest.ini_options]
-#filterwarnings = [
-#    'ignore::FutureWarning',
-#]
-#
-#[tool.pdm.build]
-#includes = ["src/climate_indices"]
+[dependency-groups]
+dev = [
+    "coverage>=7.9.2",
+    "pytest>=8.3.3",
+    "pytest-cov>=6.2.1",
+    "ruff>=0.12.2",
+    "sphinx-autodoc-typehints>=2.0.1",
+]
+

--- a/src/climate_indices/__main__.py
+++ b/src/climate_indices/__main__.py
@@ -1,13 +1,13 @@
 """Command-line interface for climate indices processing"""
 
 import argparse
-from collections import Counter
-from datetime import datetime
-from enum import Enum
 import logging
 import multiprocessing
 import os
-from typing import Any, Dict, List, Tuple
+from collections import Counter
+from datetime import datetime
+from enum import Enum
+from typing import Any
 
 import numpy as np
 import scipy.constants
@@ -563,7 +563,7 @@ def _drop_data_into_shared_arrays_grid(
     var_names: list,
     periodicity: compute.Periodicity,
     data_start_year: int,
-) -> Tuple[int, ...]:
+) -> tuple[int, ...]:
     output_shape = None
 
     # get the data arrays we'll use later in the index computations
@@ -627,8 +627,8 @@ def _drop_data_into_shared_arrays_grid(
 
 def _drop_data_into_shared_arrays_divisions(
     dataset: xr.Dataset,
-    var_names: List[str],
-) -> Tuple[int, ...]:
+    var_names: list[str],
+) -> tuple[int, ...]:
     """
     Drop data into shared arrays for use in the index computations.
 
@@ -1247,7 +1247,7 @@ def _parallel_process(
             chunk_params.append(params)
 
     else:
-        raise ValueError("Unsupported index: {index}".format(index=index))
+        raise ValueError(f"Unsupported index: {index}")
 
     # instantiate a process pool
     with multiprocessing.Pool(
@@ -1304,7 +1304,7 @@ def _apply_along_axis(params):
 
 
 def _apply_along_axis_double(
-    params: Dict[str, Any],
+    params: dict[str, Any],
 ) -> None:
     """
     Like numpy.apply_along_axis(), but with arguments in a dict instead.
@@ -1350,7 +1350,7 @@ def _apply_along_axis_double(
     output_array = _global_shared_arrays[params["output_var_name"]][_KEY_ARRAY]
     computed_array = np.frombuffer(output_array.get_obj()).reshape(shape)[start_index:end_index]
 
-    for i, (x, y) in enumerate(zip(sub_array_1, sub_array_2)):
+    for i, (x, y) in enumerate(zip(sub_array_1, sub_array_2, strict=False)):
         if params["input_type"] == InputType.grid:
             for j in range(x.shape[0]):
                 if params["index"] == "pet":
@@ -1419,7 +1419,7 @@ def _apply_along_axis_palmers(params):
     zindex_output_array = _global_shared_arrays[_KEY_RESULT_ZINDEX][_KEY_ARRAY]
     zindex = np.frombuffer(zindex_output_array.get_obj()).reshape(shape)[start_index:end_index]
 
-    for i, (precip, pet, awc) in enumerate(zip(sub_array_precip, sub_array_pet, sub_array_awc)):
+    for i, (precip, pet, awc) in enumerate(zip(sub_array_precip, sub_array_pet, sub_array_awc, strict=False)):
         if params["input_type"] == InputType.grid:
             for j in range(precip.shape[0]):
                 scpdsi[i, j], pdsi[i, j], phdi[i, j], pmdi[i, j], zindex[i, j] = func1d(

--- a/src/climate_indices/__main__.py
+++ b/src/climate_indices/__main__.py
@@ -1443,30 +1443,38 @@ def _prepare_file(
     return: name of the NetCDF file containing correct dimensions
     """
 
-    # make sure we have lat, lon, and time as variable dimensions, regardless of order
+    # make sure we have the expected dimensions for the data type
     ds = xr.open_dataset(netcdf_file)
     dimensions = ds[var_name].dims
+    
+    # Validate dimensions based on data type
     if "division" in dimensions:
+        # Climate divisions data
         if len(dimensions) == 1:
-            expected_dims = ("division",)
+            expected_dims = {"division"}
         elif len(dimensions) == 2:
-            expected_dims = ("division", "time")
+            expected_dims = {"division", "time"}
         else:
-            raise ValueError(f"Unsupported dimensions for variable '{var_name}': {dimensions}")
-    else:  # timeseries or gridded
+            message = f"Unsupported dimensions for climate division variable '{var_name}': {dimensions}"
+            _logger.error(message)
+            raise ValueError(message)
+    else:
+        # Gridded or timeseries data
         if len(dimensions) == 1:
-            expected_dims = ("time",)
+            expected_dims = {"time"}
         elif len(dimensions) == 2:
-            expected_dims = ("lat", "lon")
+            expected_dims = {"lat", "lon"}
         elif len(dimensions) == 3:
-            expected_dims = ("lat", "lon", "time")
+            expected_dims = {"lat", "lon", "time"}
         else:
             message = f"Unsupported dimensions for variable '{var_name}': {dimensions}"
             _logger.error(message)
-            raise ValueError()
+            raise ValueError(message)
 
-    if Counter(ds[var_name].dims) != Counter(expected_dims):
-        message = f"Invalid dimensions for variable '{var_name}': {ds[var_name].dims}"
+    # Validate that the actual dimensions match expected dimensions
+    actual_dims = set(dimensions)
+    if actual_dims != expected_dims:
+        message = f"Invalid dimensions for variable '{var_name}': got {actual_dims}, expected {expected_dims}"
         _logger.error(message)
         raise ValueError(message)
 

--- a/src/climate_indices/__spi__.py
+++ b/src/climate_indices/__spi__.py
@@ -1,20 +1,18 @@
 """Command-line interface for performing SPI calculations"""
 
 import argparse
-from collections import Counter
 import copy
-from datetime import datetime
-from enum import Enum
 import logging
 import multiprocessing
 import os
-from typing import Dict, List
+from collections import Counter
+from datetime import datetime
+from enum import Enum
 
 import numpy as np
 import xarray as xr
 
-from climate_indices import compute
-from climate_indices import utils, indices
+from climate_indices import compute, indices, utils
 
 # variable names for the distribution fitting parameters
 _FITTING_VARIABLES = ("alpha", "beta", "skew", "loc", "scale", "prob_zero")
@@ -239,7 +237,7 @@ def _get_variable_attributes(
 def _drop_data_into_shared_arrays_grid(
     dataset_climatology: xr.Dataset,
     dataset_fitting: xr.Dataset,
-    var_names_climate: List[str],
+    var_names_climate: list[str],
     periodicity: compute.Periodicity,
 ):
     """
@@ -347,7 +345,7 @@ def _drop_data_into_shared_arrays_grid(
 
 def _drop_data_into_shared_arrays_divisions(
     dataset: xr.Dataset,
-    var_names: List[str],
+    var_names: list[str],
 ):
     # TODO add fitting variables as we've done in _drop_data_into_shared_arrays_grid
     """
@@ -629,7 +627,7 @@ def _compute_write_index(keyword_arguments):
             time_length_366day,
         )
     else:
-        raise ValueError(f'Unsupported periodicity argument value: {keyword_arguments["periodicity"]}')
+        raise ValueError(f"Unsupported periodicity argument value: {keyword_arguments['periodicity']}")
 
     # add an array to hold index computation results
     # to our dictionary of shared memory arrays
@@ -642,8 +640,7 @@ def _compute_write_index(keyword_arguments):
     for scale in keyword_arguments["scales"]:
         for distribution in [indices.Distribution.gamma, indices.Distribution.pearson]:
             _logger.info(
-                f"Computing {scale}-{keyword_arguments['periodicity'].unit()} "
-                f"SPI ({distribution.value.capitalize()})",
+                f"Computing {scale}-{keyword_arguments['periodicity'].unit()} SPI ({distribution.value.capitalize()})",
             )
 
             # TODO we may want to initialize the shared memory array
@@ -899,12 +896,12 @@ def _parallel_spi(
 
 def _parallel_fitting(
     distribution: indices.Distribution,
-    shared_arrays: Dict,
-    input_var_names: Dict,
-    output_var_names: Dict,
+    shared_arrays: dict,
+    input_var_names: dict,
+    output_var_names: dict,
     input_type: InputType,
     number_of_workers: int,
-    args: Dict,
+    args: dict,
 ):
     """
     TODO document this function

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -1,15 +1,15 @@
 """
 Common classes and functions used to compute the various climate indices.
 """
-from enum import Enum
+
 import logging
-from typing import Tuple
+from enum import Enum
 
 import numpy as np
 import scipy.stats
 import scipy.version
 
-from climate_indices import utils, lmoments
+from climate_indices import lmoments, utils
 
 # declare the function names that should be included in the public API for this module
 __all__ = [
@@ -93,7 +93,7 @@ def _validate_array(
             values = utils.reshape_to_2d(values, 366)
 
         else:
-            message = "Unsupported periodicity argument: '{0}'".format(periodicity)
+            message = f"Unsupported periodicity argument: '{periodicity}'"
             _logger.error(message)
             raise ValueError(message)
 
@@ -101,7 +101,7 @@ def _validate_array(
         # ((values.shape[1] != 12) and (values.shape[1] != 366)):
 
         # neither a 1-D nor a 2-D array with valid shape was passed in
-        message = "Invalid input array with shape: {0}".format(values.shape)
+        message = f"Invalid input array with shape: {values.shape}"
         _logger.error(message)
         raise ValueError(message)
 
@@ -161,7 +161,7 @@ def sum_to_scale(
     # return convolve(values, np.ones(scale), mode='reflect', cval=0.0, origin=0)[start: end]
 
 
-def _log_and_raise_shape_error(shape: Tuple[int]):
+def _log_and_raise_shape_error(shape: tuple[int]):
     message = f"Invalid shape of input data array: {shape}"
     _logger.error(message)
     raise ValueError(message)
@@ -650,7 +650,7 @@ def gamma_parameters(
         elif periodicity is Periodicity.daily:
             shape = (366,)
         else:
-            raise ValueError("Unsupported periodicity: {periodicity}".format(periodicity=periodicity))
+            raise ValueError(f"Unsupported periodicity: {periodicity}")
         alphas = np.full(shape=shape, fill_value=np.nan)
         betas = np.full(shape=shape, fill_value=np.nan)
         return alphas, betas

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -248,10 +248,9 @@ def calculate_time_step_params(time_step_values):
 
     probability_of_zero = number_of_zeros / number_of_non_missing if number_of_zeros > 0 else 0.0
 
-    if (number_of_non_missing - number_of_zeros) > 3:
-        params = lmoments.fit(time_step_values)
-        return probability_of_zero, params["loc"], params["scale"], params["skew"]
-    return 0.0, 0.0, 0.0, 0.0
+    # At this point we know (number_of_non_missing - number_of_zeros) >= 4
+    params = lmoments.fit(time_step_values)
+    return probability_of_zero, params["loc"], params["scale"], params["skew"]
 
 
 def pearson_parameters(

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -2,7 +2,7 @@
 Common classes and functions used to compute the various climate indices.
 """
 from enum import Enum
-from distutils.version import LooseVersion
+# from distutils.version import LooseVersion
 import logging
 from typing import Tuple
 
@@ -21,8 +21,9 @@ __all__ = [
     "transform_fitted_pearson",
 ]
 
-# depending on the version of scipy we may need to use a workaround due to a bug in some versions of scipy
-_do_pearson3_workaround = LooseVersion(scipy.version.version) < "1.6.0"
+# # depending on the version of scipy we may need to use a workaround due to a bug in some versions of scipy
+# _do_pearson3_workaround = LooseVersion(scipy.version.version) < "1.6.0"
+_do_pearson3_workaround = False
 
 # Retrieve logger and set desired logging level
 _logger = utils.get_logger(__name__, logging.WARN)

--- a/src/climate_indices/eto.py
+++ b/src/climate_indices/eto.py
@@ -72,9 +72,7 @@ def _sunset_hour_angle(
     # validate the latitude argument
     if not _LATITUDE_RADIANS_MIN <= latitude_radians <= _LATITUDE_RADIANS_MAX:
         raise ValueError(
-            "latitude outside valid range [{0!r} to {1!r}]: {2!r}".format(
-                _LATITUDE_RADIANS_MIN, _LATITUDE_RADIANS_MAX, latitude_radians
-            )
+            f"latitude outside valid range [{_LATITUDE_RADIANS_MIN!r} to {_LATITUDE_RADIANS_MAX!r}]: {latitude_radians!r}"
         )
 
     # validate the solar declination angle argument, which can vary between
@@ -117,9 +115,9 @@ def _solar_declination(
     :raise ValueError: if the day of year value is not within the range [1-366]
     """
     if not 1 <= day_of_year <= 366:
-        raise ValueError("Day of the year must be in the range [1-366]: " "{0!r}".format(day_of_year))
+        raise ValueError(f"Day of the year must be in the range [1-366]: {day_of_year!r}")
 
-    return 0.409 * math.sin(((2.0 * math.pi / 365.0) * day_of_year - 1.39))
+    return 0.409 * math.sin((2.0 * math.pi / 365.0) * day_of_year - 1.39)
 
 
 def _daylight_hours(

--- a/src/climate_indices/indices.py
+++ b/src/climate_indices/indices.py
@@ -1,8 +1,7 @@
 """Main level API module for computing climate indices"""
 
-from enum import Enum
 import logging
-from typing import Dict
+from enum import Enum
 
 import numpy as np
 
@@ -29,7 +28,7 @@ _FITTED_INDEX_VALID_MIN = -3.09
 _FITTED_INDEX_VALID_MAX = 3.09
 
 
-def _norm_fitdict(params: Dict):
+def _norm_fitdict(params: dict):
     """
     Compatibility shim. Convert old accepted parameter dictionaries
     into new, consistently keyed parameter dictionaries. If given
@@ -74,7 +73,7 @@ def spi(
     calibration_year_initial: int,
     calibration_year_final: int,
     periodicity: compute.Periodicity,
-    fitting_params: Dict = None,
+    fitting_params: dict = None,
 ) -> np.ndarray:
     """
     Computes SPI (Standardized Precipitation Index).
@@ -139,7 +138,7 @@ def spi(
 
     # reshape precipitation values to (years, 12) for monthly, or to (years, 366) for daily
     if periodicity == compute.Periodicity.monthly:
-            values = utils.reshape_to_2d(values, 12)
+        values = utils.reshape_to_2d(values, 12)
     elif periodicity == compute.Periodicity.daily:
         values = utils.reshape_to_2d(values, 366)
     else:
@@ -335,7 +334,7 @@ def spei(
         )
 
     else:
-        message = "Unsupported distribution argument: " + "{dist}".format(dist=distribution)
+        message = "Unsupported distribution argument: " + f"{distribution}"
         _logger.error(message)
         raise ValueError(message)
 
@@ -418,8 +417,7 @@ def percentage_of_normal(
         )
     if ((calibration_end_year - calibration_start_year + 1) * 12) > values.size:
         raise ValueError(
-            "Invalid calibration period specified: total calibration years "
-            "exceeds the actual number of years of data",
+            "Invalid calibration period specified: total calibration years exceeds the actual number of years of data",
         )
 
     # get an array containing a sliding sum on the specified time step
@@ -541,8 +539,8 @@ def pci(
         denominator = 0
 
         for month in range(12):
-            numerator = numerator + (sum(rainfall_mm[start: m[month]]) ** 2)
-            denominator = denominator + sum(rainfall_mm[start: m[month]])
+            numerator = numerator + (sum(rainfall_mm[start : m[month]]) ** 2)
+            denominator = denominator + sum(rainfall_mm[start : m[month]])
 
             start = m[month]
 
@@ -555,8 +553,8 @@ def pci(
         denominator = 0
 
         for month in range(12):
-            numerator = numerator + (sum(rainfall_mm[start: m[month]]) ** 2)
-            denominator = denominator + sum(rainfall_mm[start: m[month]])
+            numerator = numerator + (sum(rainfall_mm[start : m[month]]) ** 2)
+            denominator = denominator + sum(rainfall_mm[start : m[month]])
 
             start = m[month]
 

--- a/src/climate_indices/palmer.py
+++ b/src/climate_indices/palmer.py
@@ -55,7 +55,7 @@ def _calc_recharge(
     ss: float,
     su: float,
     awc: float,
-) -> (float,float,float,float,float,float):
+) -> (float, float, float, float, float, float):
     """
     Calculate recharge, runoff, residual moisture, loss
     to both surface and under layers
@@ -210,11 +210,7 @@ def _calc_water_balances(data: dict) -> None:
             et, tl, r, ro, sss, ssu = _calc_recharge(p, pet, ss, su, data["awc"])
 
             # update sums
-            if (
-                data["calibration_year_initial_idx"]
-                <= year
-                <= data["calibration_year_final_idx"]
-            ):
+            if data["calibration_year_initial_idx"] <= year <= data["calibration_year_final_idx"]:
                 data["psum"][month] += p
                 data["spsum"][month] += sp
                 data["petsum"][month] += pet
@@ -262,9 +258,7 @@ def _calc_zindex_factors(data: dict) -> None:
 
     :param data: dictionary of parameters (intialized in pdsi)
     """
-    data["trat"] = (data["petsum"] + data["rsum"] + data["rosum"]) / (
-        data["psum"] + data["tlsum"]
-    )
+    data["trat"] = (data["petsum"] + data["rsum"] + data["rosum"]) / (data["psum"] + data["tlsum"])
 
 
 def _avg_calibration_sums(data: dict) -> None:
@@ -295,9 +289,7 @@ def _calc_kfactors(data: dict) -> None:
     :param data: dictionary of parameters (intialized in pdsi)
     """
     sabsd = np.zeros((12,))
-    for year in range(
-        data["calibration_year_initial_idx"], data["calibration_year_final_idx"] + 1
-    ):
+    for year in range(data["calibration_year_initial_idx"], data["calibration_year_final_idx"] + 1):
         for month in range(12):
             phat = (
                 data["alpha"][month] * data["pet"][year, month]
@@ -317,7 +309,7 @@ def _calc_kfactors(data: dict) -> None:
 def _case(prob: float, x1: float, x2: float, x3: float) -> float:
     """
     Select the preliminary (or near-real time) PDSI
-     
+
     Selects the PDSI from the given x values
     defined below and the probability (prob) of ending either a
     drought or wet spell.
@@ -383,7 +375,7 @@ def _assign(data: dict) -> None:
     # in sx until it is zero, then switching to the other until
     # it is zero, etc
     else:
-        for i in range(data["k8"]-1, -1, -1):
+        for i in range(data["k8"] - 1, -1, -1):
             if isave == 2:
                 if data["sx2"][i] == 0:
                     isave = 1
@@ -400,23 +392,24 @@ def _assign(data: dict) -> None:
                     data["sx"][i] = data["sx1"][i]
 
     # proper assignments to array sx have been made, output the mess
-    for idx in range(data["k8"]+1):
+    for idx in range(data["k8"] + 1):
         j = int(data["indexj"][idx])
         m = int(data["indexm"][idx])
-        data["pdsi"][j,m] = data["sx"][idx]
-        data["phdi"][j,m] = data["px3"][j,m]
+        data["pdsi"][j, m] = data["sx"][idx]
+        data["phdi"][j, m] = data["px3"][j, m]
 
-        if data["px3"][j,m] == 0:
-            data["phdi"][j,m] = data["sx"][idx]
+        if data["px3"][j, m] == 0:
+            data["phdi"][j, m] = data["sx"][idx]
 
-        data["wplm"][j,m] = _case(
-            data["ppr"][j,m],
-            data["px1"][j,m],
-            data["px2"][j,m],
-            data["px3"][j,m],
+        data["wplm"][j, m] = _case(
+            data["ppr"][j, m],
+            data["px1"][j, m],
+            data["px2"][j, m],
+            data["px3"][j, m],
         )
     data["k8"] = 0
-    #data["k8max"] = 0
+    # data["k8max"] = 0
+
 
 def _statement_220(data: dict) -> None:
     """
@@ -498,9 +491,7 @@ def _statement_200(data: dict) -> None:
         _statement_220(data)
         return
 
-    data["px2"][year, month] = min(
-        0.0, 0.897 * data["x2"] + data["z"][year, month] / 3.0
-    )
+    data["px2"][year, month] = min(0.0, 0.897 * data["x2"] + data["z"][year, month] / 3.0)
 
     # if no existing wet spell or drought x2 becomes the new x3
     if (data["px2"][year, month] <= -1) and (data["px3"][year, month] == 0):
@@ -534,8 +525,8 @@ def _statement_200(data: dict) -> None:
     # time x3 will reach a value where it is the value of x (pdsi).
     # At that time, the assign method backtracs through choosing
     # the appropriate x1 or x2 to be that month's x.
-    #_logger.debug(f"no value assigned; will backtrack later k8:{data['k8']},y:{year},m:{month}")
-    if data["k8"] >= data["sx"].shape[0]+1:
+    # _logger.debug(f"no value assigned; will backtrack later k8:{data['k8']},y:{year},m:{month}")
+    if data["k8"] >= data["sx"].shape[0] + 1:
         vals = [0] * (data["k8"] - data["sx"].shape[0] + 2)
         data["sx"] = np.append(data["sx"], vals)
         data["sx1"] = np.append(data["sx1"], vals)
@@ -650,7 +641,7 @@ def _calc_zindex(data: dict) -> None:
             data["cp"][year, month] = cet + cr + cro - cl
             cd = data["precips"][year, month] - data["cp"][year, month]
             data["z"][year, month] = data["ak"][month] * cd
-            
+
             # No abatement underway, wet or drought will end if -.5 <= X3 <= .5
             if (data["pro"] == 100) or (data["pro"] == 0):
                 # End of drought or wet
@@ -681,7 +672,7 @@ def _calc_zindex(data: dict) -> None:
                     else:
                         _statement_180(data)
                         continue
-            
+
             # Abatement is underway
             else:
                 # We are in a wet spell
@@ -695,6 +686,7 @@ def _calc_zindex(data: dict) -> None:
 
             _statement_170(data)
             continue
+
 
 def _finish_up(data: dict) -> None:
     """
@@ -834,7 +826,7 @@ def pdsi(
     calibration_year_initial: int,
     calibration_year_final: int,
     fitting_params: dict = None,
-) -> (np.ndarray,np.ndarray,np.ndarray,np.ndarray,dict):
+) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict):
     """
     Compute the Palmer Drought Severity Index (PDSI),
     Palmer Hydrological Drought Index (PHDI),
@@ -868,9 +860,7 @@ def pdsi(
 
     # clip any negative values to zero
     if np.amin(precips) < 0.0:
-        _logger.warning(
-            "Input contains negative values -- all negatives clipped to zero"
-        )
+        _logger.warning("Input contains negative values -- all negatives clipped to zero")
         precips = np.clip(precips, a_min=0.0, a_max=None)
 
     # remember the original length of the input array, in order to facilitate
@@ -900,7 +890,7 @@ def pdsi(
 
     # Sum variables now become averages over the calibration period
     # (currently not used - uncomment if want to export later)
-    #_avg_calibration_sums(data)
+    # _avg_calibration_sums(data)
 
     # reread monthly parameters for calculation of the 'K' monthly
     # weighting factors used in z-index calculation
@@ -919,4 +909,4 @@ def pdsi(
     params = {key: data[key] for key in ["alpha", "beta", "gamma", "delta"]}
 
     # return results
-    return pdsi,phdi,wplm,z,params
+    return pdsi, phdi, wplm, z, params

--- a/src/climate_indices/utils.py
+++ b/src/climate_indices/utils.py
@@ -1,8 +1,8 @@
 """Various utility/convenience functions"""
 
 import calendar
-from datetime import datetime
 import logging
+from datetime import datetime
 
 import numpy as np
 
@@ -355,7 +355,7 @@ def transform_to_366day(
         if calendar.isleap(year):
             # write the next 366 days from the original time
             # series into the all_leap array
-            all_leap[all_leap_index: (all_leap_index + 366)] = original[original_index: (original_index + 366)]
+            all_leap[all_leap_index : (all_leap_index + 366)] = original[original_index : (original_index + 366)]
 
             # increment the "start day of the current year" index for the original
             # so that the next iteration jumps ahead a full year
@@ -364,7 +364,7 @@ def transform_to_366day(
         else:
             # write the first 59 days (Jan 1 through Feb 28) from
             # the original time series into the all_leap array
-            all_leap[all_leap_index: (all_leap_index + 59)] = original[original_index: (original_index + 59)]
+            all_leap[all_leap_index : (all_leap_index + 59)] = original[original_index : (original_index + 59)]
 
             # average the Feb 28th and March 1st values as the faux Feb 29th value
             all_leap[all_leap_index + 59] = (original[original_index + 58] + original[original_index + 59]) / 2
@@ -374,8 +374,8 @@ def transform_to_366day(
             original_year_end_index = original_index + 365
             if len(original) < original_year_end_index:
                 # this should be the final year, and we're just adding the remained days
-                remainder = original[original_index + 59:]
-                difference = len(all_leap[all_leap_index + 60:]) - len(remainder)
+                remainder = original[original_index + 59 :]
+                difference = len(all_leap[all_leap_index + 60 :]) - len(remainder)
                 if difference > 0:
                     final_days = np.pad(
                         remainder,
@@ -390,11 +390,11 @@ def transform_to_366day(
                     raise ValueError("Incompatible shapes")
                 else:
                     final_days = remainder
-                all_leap[all_leap_index + 60:] = final_days
+                all_leap[all_leap_index + 60 :] = final_days
                 continue
             else:
-                all_leap[all_leap_index + 60: (all_leap_index + 366)] = original[
-                    original_index + 59: original_year_end_index
+                all_leap[all_leap_index + 60 : (all_leap_index + 366)] = original[
+                    original_index + 59 : original_year_end_index
                 ]
 
             # increment the "start day of the current year" index for the original
@@ -468,7 +468,7 @@ def transform_to_gregorian(
         if calendar.isleap(year):
             # write the next 366 days from the original
             # time series into the gregorian array
-            gregorian[gregorian_index: (gregorian_index + 366)] = original[original_index: (original_index + 366)]
+            gregorian[gregorian_index : (gregorian_index + 366)] = original[original_index : (original_index + 366)]
 
             # increment the "start day of the current year" index for the original
             # so the next iteration jumps ahead a full year
@@ -477,12 +477,12 @@ def transform_to_gregorian(
         else:
             # write the first 59 days (Jan 1 through Feb 28) from the original
             # time series into the gregorian array
-            gregorian[gregorian_index: (gregorian_index + 59)] = original[original_index: (original_index + 59)]
+            gregorian[gregorian_index : (gregorian_index + 59)] = original[original_index : (original_index + 59)]
 
             # write the remaining days of the year (Mar 1 through Dec 31)
             # from the original into the gregorian array
-            gregorian[(gregorian_index + 59): (gregorian_index + 365)] = original[
-                (original_index + 60): (original_index + 366)
+            gregorian[(gregorian_index + 59) : (gregorian_index + 365)] = original[
+                (original_index + 60) : (original_index + 366)
             ]
 
             # increment the "start day of the current year" index for

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 import numpy as np
 import pytest
@@ -210,6 +210,5 @@ def rain_mm_366():
 
 @pytest.fixture(scope="module")
 def palmer_awcs():
-    with open(os.path.join(os.path.split(__file__)[0], "fixture", "palmer_awc.json"),"r") as awcfile:
+    with open(os.path.join(os.path.split(__file__)[0], "fixture", "palmer_awc.json")) as awcfile:
         return json.load(awcfile)
-

--- a/tests/test_palmer.py
+++ b/tests/test_palmer.py
@@ -1,15 +1,15 @@
-import logging
 import os
+from glob import glob
 
 import numpy as np
 import pytest
-from glob import glob
 
 from climate_indices import palmer
 
 # Tests for `climate_indices.palmer.py`
-ATOL = 5E-5
+ATOL = 5e-5
 RTOL = 0
+
 
 # ---------------------------------------------------------------------------------------
 @pytest.mark.usefixtures(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_count_zeros_and_non_missings():
     # messages used multiple times below
     zero_count_error = "Failed to correctly count zero values"
     non_missing_count_error = "Failed to correctly count non-missing values"
-    
+
     # vanilla use case
     values_list = [3, 4, 0, 2, 3.1, 5, np.nan, 8, 5, 6, 0.0, np.nan, 5.6, 2]
     values = np.array(values_list)


### PR DESCRIPTION
Updates to allow for Python 3.13. Since we need the latest version of scipy which itself requires Python 3.10 we will have to drop support for 3.8 and 3.9 if this is merged.

## Summary by Sourcery

Add support for Python 3.13 by updating dependencies and configuration, including scipy to version 1.14.1. Drop support for Python 3.8 and 3.9, and update CI to test against newer Python versions.

New Features:
- Add support for Python 3.13 by updating dependencies and configuration.

Enhancements:
- Update scipy dependency to version 1.14.1 to ensure compatibility with Python 3.13.
- Remove workaround for scipy bug related to Pearson3 distribution as it is no longer needed.

Build:
- Update Python version compatibility in pyproject.toml to support Python 3.10 to 3.13 and drop support for 3.8 and 3.9.

CI:
- Update CI configuration to test against Python versions 3.10, 3.11, 3.12, and 3.13.