### PR TITLE
Fix SPI Gamma calculation for zero inputs (Issue #533)

### DIFF
--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -82,13 +82,20 @@ def test_transform_fitted_gamma(
         calibration_year_end_daily,
         compute.Periodicity.daily,
     )
+    
+    # Check that non-NaN values in fixture match
+    mask_valid_fixture = ~np.isnan(transformed_gamma_daily)
     np.testing.assert_allclose(
-        computed_values,
-        transformed_gamma_daily,
+        computed_values[mask_valid_fixture],
+        transformed_gamma_daily[mask_valid_fixture],
         atol=0.001,
-        equal_nan=True,
-        err_msg="Transformed gamma fitted daily values not computed as expected",
+        err_msg="Transformed gamma fitted daily values mismatch on valid fixture values"
     )
+
+    # Check that values where input was zero are NOT NaN in computed result
+    mask_zeros = (precips_mm_daily == 0)
+    assert not np.any(np.isnan(computed_values[mask_zeros])), \
+            "Computed SPI should not be NaN for zero precipitation"
 
     # confirm that we can call with a calibration period out of the valid range
     # and as a result use the full period of record as the calibration period instead


### PR DESCRIPTION
### Description
Fixes a bug where SPI calculation would return `NaN` for input values of `0.0` when using the Gamma distribution.
### Fix Details
- **`src/climate_indices/compute.py`**:
- Updated `gamma_parameters` to operate on a copy of the input array, preventing side effects (in-place modification) on the user's data.
- Updated `transform_fitted_gamma` to use explicit masking for zero values. It now correctly treats the zero-probability mass by forcing the Gamma CDF contribution  to `0.0` for zero inputs, preventing `NaN` propagation.

### Verification
- Updated `tests/test_compute.py` to verify that zero inputs now produce valid SPI values.
- Verified that existing regression tests pass.

Resolves #533

## Summary by Sourcery

Fix SPI Gamma transformation to handle zero inputs without mutating caller data or producing NaNs.

Bug Fixes:
- Prevent NaN SPI outputs when transforming fitted Gamma distributions with zero-valued inputs by explicitly treating zeros as a separate probability mass with zero Gamma CDF contribution.
- Avoid unintended in-place modification of user input arrays during Gamma parameter estimation and transformation.

Tests:
- Update SPI Gamma transformation tests to compare only valid (non-NaN) fixture values and to assert that zero-precipitation inputs yield non-NaN SPI values.