### PR TITLE
Fix SPI calculation for zero precipitation inputs

### DIFF
--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -913,6 +913,12 @@ def transform_fitted_gamma(
     zeros = (values == 0).sum(axis=0)
     probabilities_of_zero = zeros / values.shape[0]
 
+    # If a time step has all zeros (probability of zero is 1.0), the resulting SPI
+    # should be NaN (undefined) rather than +infinity (which would imply extreme wetness).
+    # We identify these time steps and set their probability of zero to NaN so that
+    # subsequent calculations result in NaN.
+    probabilities_of_zero[probabilities_of_zero == 1.0] = np.nan
+
     # create a working copy to avoid modifying the input array
     # and to safely replace zeros with NaNs for fitting/CDF computation
     values_for_fitting = values.copy()

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -744,6 +744,25 @@ def transform_fitted_pearson(
     return values
 
 
+def _replace_zeros_with_nan(values: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Create a copy of values with zeros replaced by NaN.
+
+    This helper centralizes the zero-to-NaN conversion logic used when fitting
+    gamma distributions, where zeros must be excluded from the fitting process
+    but their positions need to be tracked for later probability calculations.
+
+    :param values: Input array potentially containing zeros
+    :return: Tuple of (zero_mask, values_copy) where:
+        - zero_mask: Boolean array where True indicates original zero positions
+        - values_copy: Copy of input with zeros replaced by NaN
+    """
+    values_copy = values.copy()
+    zero_mask = values == 0
+    values_copy[zero_mask] = np.nan
+    return zero_mask, values_copy
+
+
 def gamma_parameters(
     values: np.ndarray,
     data_start_year: int,
@@ -788,10 +807,10 @@ def gamma_parameters(
         return alphas, betas
 
     # validate (and possibly reshape) the input array
-    values = _validate_array(values, periodicity).copy()
+    values = _validate_array(values, periodicity)
 
-    # replace zeros with NaNs
-    values[values == 0] = np.nan
+    # replace zeros with NaNs (zeros are excluded from gamma fitting)
+    _, values = _replace_zeros_with_nan(values)
 
     # determine the end year of the values array
     data_end_year = data_start_year + values.shape[0]
@@ -909,25 +928,26 @@ def transform_fitted_gamma(
     # validate (and possibly reshape) the input array
     values = _validate_array(values, periodicity)
 
+    # Replace zeros with NaNs for fitting (zeros are excluded from gamma fitting)
+    # and get mask of zero positions for later probability calculations
+    zero_mask, values_for_fitting = _replace_zeros_with_nan(values)
+
     # find the percentage of zero values for each time step
-    zeros = (values == 0).sum(axis=0)
+    zeros = zero_mask.sum(axis=0)
     probabilities_of_zero = zeros / values.shape[0]
 
     # If a time step has all zeros (probability of zero is 1.0), the resulting SPI
-    # should be NaN (undefined) rather than +infinity (which would imply extreme wetness).
-    # We identify these time steps and set their probability of zero to NaN so that
-    # subsequent calculations result in NaN.
-    probabilities_of_zero[probabilities_of_zero == 1.0] = np.nan
-
-    # create a working copy to avoid modifying the input array
-    # and to safely replace zeros with NaNs for fitting/CDF computation
-    values_for_fitting = values.copy()
-
-    # store mask of zero values
-    zero_mask = (values == 0)
-
-    # replace zeros with NaNs
-    values_for_fitting[zero_mask] = np.nan
+    # would be +infinity (extreme wetness) which is incorrect for a dry region.
+    # We set probability_of_zero to 0.0 for these time steps, which means:
+    #   - gamma_parameters() will return NaN (since all values become NaN after
+    #     zero replacement)
+    #   - gamma.cdf() will return NaN
+    #   - gamma_probabilities[zero_mask] = 0.0 forces these to 0.0
+    #   - Final probability = 0.0 + (1.0 * 0.0) = 0.0
+    #   - norm.ppf(0.0) = -infinity (extreme drought)
+    # This is the correct interpretation: a location with 100% zero precipitation
+    # in the historical record is in extreme drought, not extreme wetness.
+    probabilities_of_zero[probabilities_of_zero == 1.0] = 0.0
 
     # compute fitting parameters if none were provided
     if (alphas is None) or (betas is None):

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -947,7 +947,7 @@ def transform_fitted_gamma(
     #   - norm.ppf(0.0) = -infinity (extreme drought)
     # This is the correct interpretation: a location with 100% zero precipitation
     # in the historical record is in extreme drought, not extreme wetness.
-    probabilities_of_zero[probabilities_of_zero == 1.0] = 0.0
+    probabilities_of_zero[np.isclose(probabilities_of_zero, 1.0)] = 0.0
 
     # compute fitting parameters if none were provided
     if (alphas is None) or (betas is None):


### PR DESCRIPTION
### Summary

Fixes incorrect SPI (Standardized Precipitation Index) output when precipitation data contains zeros. Previously, zero precipitation values could produce NaN results due to issues in the gamma distribution fitting process. This MR ensures zeros are handled correctly and produce meaningful drought indicators.

### Problem

When computing SPI using gamma distribution fitting (transform_fitted_gamma), zero precipitation values caused two issues:

1. Zeros passed to gamma CDF: The scipy.stats.gamma.cdf() function received zero values, which combined with the fitted gamma parameters could produce NaN outputs
2. All-zero time steps: When a calendar day/month had 100% zero precipitation in the historical record, the resulting SPI was undefined or incorrectly indicated extreme wetness (+∞)

### Solution

#### Core fix: Proper zero-value handling in gamma fitting

- Zeros are now explicitly excluded from gamma parameter fitting by replacing them with NaN before calling gamma_parameters()
- A zero_mask tracks original zero positions for later probability adjustment
- After computing gamma.cdf(), zero positions are assigned a gamma probability of 0.0 (the correct value for the lower bound of the distribution)
- The final probability calculation correctly combines the probability-of-zero with the gamma probability

All-zero time steps produce extreme drought (-∞)

When probability_of_zero == 1.0 (all historical values are zero for a time step), the SPI now correctly returns -∞ (extreme drought) rather than NaN or +∞. This is the correct climatological interpretation: a location with no recorded precipitation is in perpetual extreme drought.

### Code quality improvements

- Added _replace_zeros_with_nan() helper to centralize duplicated zero-handling logic between gamma_parameters() and transform_fitted_gamma()
- Compute zero_mask once and reuse it (avoids redundant values == 0 comparisons)
- Added comprehensive inline documentation explaining the all-zero edge case behavior

### Changes

| File                           | Changes                                                                                                                      |
|--------------------------------|------------------------------------------------------------------------------------------------------------------------------|
| src/climate_indices/compute.py | Added _replace_zeros_with_nan() helper; refactored gamma_parameters() and transform_fitted_gamma() to handle zeros correctly |
| tests/test_compute.py          | Enhanced assertions for zero-precipitation; added dedicated test_transform_fitted_gamma_all_zeros_produces_finite_spi()      |

### Test plan

- Existing test_transform_fitted_gamma passes with enhanced zero-value assertions
- New test_transform_fitted_gamma_all_zeros_produces_finite_spi verifies all-zero input produces -∞ (not NaN)
- All 6 tests in test_compute.py pass
- Linting passes (ruff check)

### Behavior summary

| Input condition                                | Previous behavior | New behavior                       |
|------------------------------------------------|-------------------|------------------------------------|
| Zero precipitation (zeros rare historically)   | NaN               | Negative SPI (drought)             |
| Zero precipitation (zeros common historically) | NaN               | Near-zero or positive SPI (normal) |
| All-zero time step (100% zeros in history)     | NaN or +∞         | -∞ (extreme drought)               |

## Summary by Sourcery

Handle zero-precipitation values correctly in SPI gamma-distribution transformation and centralize zero-handling logic.

Bug Fixes:
- Prevent NaN and incorrect +∞ SPI values by correctly handling zero and all-zero precipitation cases in gamma-based SPI computation.

Enhancements:
- Introduce a shared _replace_zeros_with_nan helper and reuse zero masks to simplify and clarify gamma fitting logic and edge-case behavior.

Tests:
- Expand SPI zero-precipitation assertions and add a dedicated test ensuring all-zero precipitation inputs yield finite, negative SPI values rather than NaNs or +∞.