### PR TITLE
Address audit follow-up findings

### DIFF
--- a/src/climate_indices/__main__.py
+++ b/src/climate_indices/__main__.py
@@ -13,6 +13,7 @@ import scipy.constants
 import xarray as xr
 
 from climate_indices import compute, indices, utils
+from climate_indices.exceptions import ClimateIndicesError, DataShapeError
 
 # the number of worker processes we'll use for process pools
 _NUMBER_OF_WORKER_PROCESSES = multiprocessing.cpu_count() - 1
@@ -619,7 +620,11 @@ def _drop_data_into_shared_arrays_grid(
         # drop the variable from the dataset (we're assuming this frees the memory)
         dataset = dataset.drop_vars(names=[var_name])
 
-    assert output_shape is not None, "No variables processed; output shape is unknown"
+    if output_shape is None:
+        raise DataShapeError(
+            "No variables processed; output shape is unknown",
+            expected_shape="one or more processed variables",
+        )
     return output_shape
 
 
@@ -672,7 +677,11 @@ def _drop_data_into_shared_arrays_divisions(
         # drop the variable from the dataset (we're assuming this frees the memory)
         dataset = dataset.drop_vars(names=[var_name])
 
-    assert output_shape is not None, "No variables processed; output shape is unknown"
+    if output_shape is None:
+        raise DataShapeError(
+            "No variables processed; output shape is unknown",
+            expected_shape="one or more processed variables with 2-D output",
+        )
     return output_shape
 
 
@@ -1691,7 +1700,8 @@ def process_climate_indices(
 
                 # run PET computation, getting the PET file and corresponding variable name for later use
                 result = _compute_write_index(kwargs)
-                assert result is not None, "PET computation should return file and variable name"
+                if result is None:
+                    raise ClimateIndicesError("PET computation should return file and variable name")
                 arguments.netcdf_pet, arguments.var_name_pet = result
 
                 # remove temporary file

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -998,7 +998,7 @@ def _check_goodness_of_fit_pearson(
 
         # skip time steps where fitting failed (all parameters are zero)
         # Pearson fitting failures are encoded by exact zero sentinels.
-        if np.array_equal(np.array([loc, scale, skew]), np.zeros(3)):
+        if loc == 0 and scale == 0 and skew == 0:
             continue
 
         # filter out NaN and zero values for non-zero distribution

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -835,11 +835,8 @@ def transform_fitted_pearson(
             periodicity,
         )
 
-    # mypy narrowing: at this point parameters are guaranteed to be non-None
-    assert probabilities_of_zero is not None
-    assert locs is not None
-    assert scales is not None
-    assert skews is not None
+    if probabilities_of_zero is None or locs is None or scales is None or skews is None:
+        raise PearsonFittingError("Pearson Type III fitting parameters could not be resolved")
 
     # fit each value to the Pearson Type III distribution
     values = _pearson_fit(values, probabilities_of_zero, skews, locs, scales)
@@ -937,8 +934,13 @@ def _check_goodness_of_fit_gamma(
                 )
                 if p_value < GOODNESS_OF_FIT_P_VALUE_THRESHOLD:
                     poor_fit_steps.append((time_step_index, p_value))
-            except Exception:
-                # ignore fitting errors during goodness-of-fit check
+            except (ArithmeticError, TypeError, ValueError) as exc:
+                _logger.debug(
+                    "goodness_of_fit_check_skipped",
+                    distribution="gamma",
+                    time_step_index=time_step_index,
+                    error_type=type(exc).__name__,
+                )
                 continue
 
     if poor_fit_steps:
@@ -993,7 +995,7 @@ def _check_goodness_of_fit_pearson(
         skew = skews[time_step_index]
 
         # skip time steps where fitting failed (all parameters are zero)
-        if loc == 0 and scale == 0 and skew == 0:
+        if np.isclose(loc, 0.0) and np.isclose(scale, 0.0) and np.isclose(skew, 0.0):
             continue
 
         # filter out NaN and zero values for non-zero distribution
@@ -1012,8 +1014,13 @@ def _check_goodness_of_fit_pearson(
                 )
                 if p_value < GOODNESS_OF_FIT_P_VALUE_THRESHOLD:
                     poor_fit_steps.append((time_step_index, p_value))
-            except Exception:
-                # ignore fitting errors during goodness-of-fit check
+            except (ArithmeticError, TypeError, ValueError) as exc:
+                _logger.debug(
+                    "goodness_of_fit_check_skipped",
+                    distribution="pearson3",
+                    time_step_index=time_step_index,
+                    error_type=type(exc).__name__,
+                )
                 continue
 
     if poor_fit_steps:

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -835,6 +835,8 @@ def transform_fitted_pearson(
             periodicity,
         )
 
+    # Keep this as an explicit runtime check rather than an assert so optimized
+    # Python cannot skip validation if future changes break the guarantee above.
     if probabilities_of_zero is None or locs is None or scales is None or skews is None:
         raise PearsonFittingError("Pearson Type III fitting parameters could not be resolved")
 
@@ -934,7 +936,7 @@ def _check_goodness_of_fit_gamma(
                 )
                 if p_value < GOODNESS_OF_FIT_P_VALUE_THRESHOLD:
                     poor_fit_steps.append((time_step_index, p_value))
-            except (ArithmeticError, TypeError, ValueError) as exc:
+            except Exception as exc:
                 _logger.debug(
                     "goodness_of_fit_check_skipped",
                     distribution="gamma",
@@ -995,7 +997,8 @@ def _check_goodness_of_fit_pearson(
         skew = skews[time_step_index]
 
         # skip time steps where fitting failed (all parameters are zero)
-        if np.isclose(loc, 0.0) and np.isclose(scale, 0.0) and np.isclose(skew, 0.0):
+        # Pearson fitting failures are encoded by exact zero sentinels.
+        if np.array_equal(np.array([loc, scale, skew]), np.zeros(3)):
             continue
 
         # filter out NaN and zero values for non-zero distribution
@@ -1014,7 +1017,7 @@ def _check_goodness_of_fit_pearson(
                 )
                 if p_value < GOODNESS_OF_FIT_P_VALUE_THRESHOLD:
                     poor_fit_steps.append((time_step_index, p_value))
-            except (ArithmeticError, TypeError, ValueError) as exc:
+            except Exception as exc:
                 _logger.debug(
                     "goodness_of_fit_check_skipped",
                     distribution="pearson3",

--- a/src/climate_indices/typed_public_api.py
+++ b/src/climate_indices/typed_public_api.py
@@ -29,6 +29,7 @@ import xarray as xr
 from climate_indices import indices
 from climate_indices.cf_metadata_registry import CF_METADATA
 from climate_indices.compute import Periodicity
+from climate_indices.exceptions import InputTypeError
 from climate_indices.indices import Distribution
 from climate_indices.xarray_adapter import (
     InputType,
@@ -367,11 +368,21 @@ def pci(
     input_type = detect_input_type(rainfall_mm)
 
     if input_type == InputType.NUMPY:
-        assert isinstance(rainfall_mm, np.ndarray)
+        if not isinstance(rainfall_mm, np.ndarray):
+            raise InputTypeError(
+                "PCI NumPy path requires rainfall_mm to be a numpy.ndarray",
+                expected_type=np.ndarray,
+                actual_type=type(rainfall_mm),
+            )
         return indices.pci(rainfall_mm)
 
     # xarray path: extract values, compute, rewrap with CF metadata
-    assert isinstance(rainfall_mm, xr.DataArray)
+    if not isinstance(rainfall_mm, xr.DataArray):
+        raise InputTypeError(
+            "PCI xarray path requires rainfall_mm to be an xarray.DataArray",
+            expected_type=xr.DataArray,
+            actual_type=type(rainfall_mm),
+        )
     result_values = indices.pci(rainfall_mm.values)
 
     # build CF metadata attributes for the scalar output

--- a/src/climate_indices/xarray_adapter.py
+++ b/src/climate_indices/xarray_adapter.py
@@ -1728,13 +1728,22 @@ def pet_thornthwaite(
         # delegate to indices.pet with explicit data_start_year requirement
         if data_start_year is None:
             raise ValueError("data_start_year is required for numpy inputs")
-        # narrow type for mypy
-        assert isinstance(temperature, np.ndarray)
+        if not isinstance(temperature, np.ndarray):
+            raise InputTypeError(
+                "PET Thornthwaite NumPy path requires temperature to be a numpy.ndarray",
+                expected_type=np.ndarray,
+                actual_type=type(temperature),
+            )
         return indices.pet(temperature, lat_float, data_start_year)
 
     # xarray path: validate → infer → compute → rewrap
     # at this point temperature must be an xr.DataArray (numpy path returned above)
-    assert isinstance(temperature, xr.DataArray)
+    if not isinstance(temperature, xr.DataArray):
+        raise InputTypeError(
+            "PET Thornthwaite xarray path requires temperature to be an xarray.DataArray",
+            expected_type=xr.DataArray,
+            actual_type=type(temperature),
+        )
     temp_da = temperature
 
     # validate time dimension
@@ -1748,7 +1757,8 @@ def pet_thornthwaite(
         _log().debug(
             "pet_data_start_year_inferred",
             inferred_year=data_start_year,
-            time_coord_first=str(time_coord.values[0]),
+            time_coord_length=len(time_coord),
+            time_coord_dtype=str(time_coord.dtype),
         )
 
     # normalize latitude for xr.apply_ufunc
@@ -1958,17 +1968,36 @@ def pet_hargreaves(
         # convert latitude to float if it's a numpy scalar
         lat_float = float(latitude) if isinstance(latitude, np.floating) else latitude
         # auto-derive tmean as per Hargreaves standard approach
-        # narrow types for mypy
-        assert isinstance(daily_tmin_celsius, np.ndarray)
-        assert isinstance(daily_tmax_celsius, np.ndarray)
+        if not isinstance(daily_tmin_celsius, np.ndarray):
+            raise InputTypeError(
+                "PET Hargreaves NumPy path requires daily_tmin_celsius to be a numpy.ndarray",
+                expected_type=np.ndarray,
+                actual_type=type(daily_tmin_celsius),
+            )
+        if not isinstance(daily_tmax_celsius, np.ndarray):
+            raise InputTypeError(
+                "PET Hargreaves NumPy path requires daily_tmax_celsius to be a numpy.ndarray",
+                expected_type=np.ndarray,
+                actual_type=type(daily_tmax_celsius),
+            )
         tmean = (daily_tmin_celsius + daily_tmax_celsius) / 2.0
         # delegate to eto.eto_hargreaves
         return eto.eto_hargreaves(daily_tmin_celsius, daily_tmax_celsius, tmean, lat_float)
 
     # xarray path: validate → align → compute → rewrap
     # at this point both inputs must be xr.DataArray (numpy path returned above)
-    assert isinstance(daily_tmin_celsius, xr.DataArray)
-    assert isinstance(daily_tmax_celsius, xr.DataArray)
+    if not isinstance(daily_tmin_celsius, xr.DataArray):
+        raise InputTypeError(
+            "PET Hargreaves xarray path requires daily_tmin_celsius to be an xarray.DataArray",
+            expected_type=xr.DataArray,
+            actual_type=type(daily_tmin_celsius),
+        )
+    if not isinstance(daily_tmax_celsius, xr.DataArray):
+        raise InputTypeError(
+            "PET Hargreaves xarray path requires daily_tmax_celsius to be an xarray.DataArray",
+            expected_type=xr.DataArray,
+            actual_type=type(daily_tmax_celsius),
+        )
     tmin_da = daily_tmin_celsius
     tmax_da = daily_tmax_celsius
 

--- a/tests/test_data_quality_warnings.py
+++ b/tests/test_data_quality_warnings.py
@@ -308,7 +308,7 @@ class TestGoodnessOfFitWarning:
                 events.append((event, kwargs))
 
         def failing_kstest(*args: object, **kwargs: object) -> tuple[float, float]:
-            raise ValueError("sensitive input value 1980-01-01")
+            raise RuntimeError("sensitive input value 1980-01-01")
 
         monkeypatch.setattr(compute, "_logger", FakeLogger())
         monkeypatch.setattr(compute.scipy.stats, "kstest", failing_kstest)
@@ -332,10 +332,40 @@ class TestGoodnessOfFitWarning:
         assert events == [
             (
                 "goodness_of_fit_check_skipped",
-                {"distribution": distribution, "time_step_index": 0, "error_type": "ValueError"},
+                {"distribution": distribution, "time_step_index": 0, "error_type": "RuntimeError"},
             )
         ]
         assert "sensitive input value" not in repr(events)
+
+    def test_pearson_goodness_of_fit_uses_exact_zero_failure_sentinel(self, monkeypatch) -> None:
+        """Very small fitted parameters should still reach the KS check."""
+        calls = 0
+
+        def counting_kstest(*args: object, **kwargs: object) -> tuple[float, float]:
+            nonlocal calls
+            calls += 1
+            return 0.0, 1.0
+
+        monkeypatch.setattr(compute.scipy.stats, "kstest", counting_kstest)
+        calibration_values = np.array([[1.0], [2.0], [3.0]])
+
+        compute._check_goodness_of_fit_pearson(
+            calibration_values,
+            probabilities_of_zero=np.array([0.0]),
+            locs=np.array([0.0]),
+            scales=np.array([0.0]),
+            skews=np.array([0.0]),
+        )
+        assert calls == 0
+
+        compute._check_goodness_of_fit_pearson(
+            calibration_values,
+            probabilities_of_zero=np.array([0.0]),
+            locs=np.array([1e-12]),
+            scales=np.array([1e-12]),
+            skews=np.array([1e-12]),
+        )
+        assert calls == 1
 
     def test_gamma_parameters_warns_on_poor_fit(self) -> None:
         """gamma_parameters should warn when KS test indicates poor gamma fit."""

--- a/tests/test_data_quality_warnings.py
+++ b/tests/test_data_quality_warnings.py
@@ -298,6 +298,45 @@ class TestShortCalibrationWarning:
 class TestGoodnessOfFitWarning:
     """Test GoodnessOfFitWarning emission when distribution fit is poor."""
 
+    @pytest.mark.parametrize("distribution", ["gamma", "pearson3"])
+    def test_goodness_of_fit_logs_skipped_ks_errors_without_data_values(self, monkeypatch, distribution: str) -> None:
+        """Skipped goodness-of-fit checks should log metadata, not exception text."""
+        events: list[tuple[str, dict[str, object]]] = []
+
+        class FakeLogger:
+            def debug(self, event: str, **kwargs: object) -> None:
+                events.append((event, kwargs))
+
+        def failing_kstest(*args: object, **kwargs: object) -> tuple[float, float]:
+            raise ValueError("sensitive input value 1980-01-01")
+
+        monkeypatch.setattr(compute, "_logger", FakeLogger())
+        monkeypatch.setattr(compute.scipy.stats, "kstest", failing_kstest)
+
+        calibration_values = np.array([[1.0], [2.0], [3.0]])
+        if distribution == "gamma":
+            compute._check_goodness_of_fit_gamma(
+                calibration_values,
+                alphas=np.array([1.0]),
+                betas=np.array([1.0]),
+            )
+        else:
+            compute._check_goodness_of_fit_pearson(
+                calibration_values,
+                probabilities_of_zero=np.array([0.0]),
+                locs=np.array([1.0]),
+                scales=np.array([1.0]),
+                skews=np.array([0.5]),
+            )
+
+        assert events == [
+            (
+                "goodness_of_fit_check_skipped",
+                {"distribution": distribution, "time_step_index": 0, "error_type": "ValueError"},
+            )
+        ]
+        assert "sensitive input value" not in repr(events)
+
     def test_gamma_parameters_warns_on_poor_fit(self) -> None:
         """gamma_parameters should warn when KS test indicates poor gamma fit."""
         # create data that poorly fits gamma (uniform distribution mixed with gamma)

--- a/tests/test_data_quality_warnings.py
+++ b/tests/test_data_quality_warnings.py
@@ -329,12 +329,12 @@ class TestGoodnessOfFitWarning:
                 skews=np.array([0.5]),
             )
 
-        assert events == [
-            (
-                "goodness_of_fit_check_skipped",
-                {"distribution": distribution, "time_step_index": 0, "error_type": "RuntimeError"},
-            )
-        ]
+        assert len(events) == 1
+        event, payload = events[0]
+        required_payload = {"distribution": distribution, "time_step_index": 0, "error_type": "RuntimeError"}
+        assert event == "goodness_of_fit_check_skipped"
+        assert required_payload.keys() <= payload.keys()
+        assert {key: payload[key] for key in required_payload} == required_payload
         assert "sensitive input value" not in repr(events)
 
     def test_pearson_goodness_of_fit_uses_exact_zero_failure_sentinel(self, monkeypatch) -> None:

--- a/tests/test_pattern_compliance.py
+++ b/tests/test_pattern_compliance.py
@@ -34,6 +34,21 @@ _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "climate_indices"
 _TEST_ROOT = Path(__file__).resolve().parent
 
 
+class TestSecurityPatternCompliance:
+    """Verify source code avoids security-sensitive runtime patterns."""
+
+    def test_source_runtime_code_has_no_assert_statements(self) -> None:
+        """Runtime validation should use explicit exceptions, not assert."""
+        assert_locations: list[str] = []
+        for source_file in _SRC_ROOT.glob("*.py"):
+            tree = ast.parse(source_file.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Assert):
+                    assert_locations.append(f"{source_file.name}:{node.lineno}")
+
+        assert not assert_locations, "Source files contain runtime assert statements: " + ", ".join(assert_locations)
+
+
 # ---------------------------------------------------------------------------
 # The 7 indices and their mapping to source modules + functions
 # ---------------------------------------------------------------------------

--- a/tests/test_pattern_compliance.py
+++ b/tests/test_pattern_compliance.py
@@ -44,7 +44,8 @@ class TestSecurityPatternCompliance:
             tree = ast.parse(source_file.read_text())
             for node in ast.walk(tree):
                 if isinstance(node, ast.Assert):
-                    assert_locations.append(f"{source_file.name}:{node.lineno}")
+                    relative_path = source_file.relative_to(_SRC_ROOT.parent.parent).as_posix()
+                    assert_locations.append(f"{relative_path}:{node.lineno}")
 
         assert not assert_locations, "Source files contain runtime assert statements: " + ", ".join(assert_locations)
 

--- a/tests/test_pattern_compliance.py
+++ b/tests/test_pattern_compliance.py
@@ -40,7 +40,7 @@ class TestSecurityPatternCompliance:
     def test_source_runtime_code_has_no_assert_statements(self) -> None:
         """Runtime validation should use explicit exceptions, not assert."""
         assert_locations: list[str] = []
-        for source_file in _SRC_ROOT.glob("*.py"):
+        for source_file in _SRC_ROOT.glob("**/*.py"):
             tree = ast.parse(source_file.read_text())
             for node in ast.walk(tree):
                 if isinstance(node, ast.Assert):

--- a/uv.lock
+++ b/uv.lock
@@ -1391,11 +1391,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -1412,7 +1412,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [


### PR DESCRIPTION
# Summary

- Replace source runtime `assert` statements with explicit climate-indices exception paths.
- Make goodness-of-fit KS-test failures observable while preserving advisory continue behavior.
- Stop logging the first PET time coordinate value during data-start-year inference.
- Add regression coverage for source assert compliance, safe goodness-of-fit logging, and exact Pearson failure sentinel behavior.
- Bump locked `idna` from 3.11 to 3.16 to clear the GitHub `security-audit` pip-audit finding.

# Validation

- `uv lock --check`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uv run pytest -m "not benchmark and not validation"`: 1039 passed, 9 skipped, 24 deselected
- `uv run pytest tests/test_pattern_compliance.py -v`: 81 passed
- `uv run ruff check --select S src/`
- `uv run pip-audit`
- `uv run --group security pip-audit --requirement reports/audit/raw/runtime-requirements.txt --disable-pip`

Known pre-existing validation gap:

- `uv run pytest -m validation` selects 0 tests and exits with code 5 because no tests currently carry the `validation` marker.

# Audit Review

- `/octo:review` was run locally against `/private/tmp/climate-indices-audit-followups.diff` with `publish=never`.
- First sandboxed run failed to write result files under `~/.claude-octopus`; escalated rerun completed.
- Final review findings were triaged and addressed in commit `f49ac66`.

# Follow-Up Issues

- https://github.com/monocongo/climate_indices/issues/660
- https://github.com/monocongo/climate_indices/issues/661
- https://github.com/monocongo/climate_indices/issues/662
- https://github.com/monocongo/climate_indices/issues/663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting with descriptive messages for invalid inputs and missing computation results.
  * Improved logging for diagnostic debugging during data fitting operations.

* **Tests**
  * Added validation tests for input type checking and error handling accuracy.
  * Introduced code quality checks to enforce runtime validation standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monocongo/climate_indices/pull/664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->