### PR TITLE
docs(agents): require branch-based pushes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ are recorded as ADRs in [`docs/adr/`](docs/adr/).
   short-lived branch, commit there, push that branch to `origin`, then open a
   PR into `main`.
 - If work begins on `main`, create the branch before making the task commit.
+- If work begins on `main` with uncommitted changes, inspect them first.
+  Stop and ask for confirmation before committing or publishing pre-existing
+  or unrelated changes.
 - Before every push, inspect the destination ref and commits to be published.
   Stop and ask for confirmation if the branch includes pre-existing or
   unrelated commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,20 @@ are recorded as ADRs in [`docs/adr/`](docs/adr/).
 - Merge only after CI passes.
 - Avoid long-lived `release/*` branches except approved maintenance work.
 
+## Git safety (non-negotiable)
+
+- Never commit directly on `main` or push directly to `origin/main`.
+- Interpret “commit and push” as: create or update an appropriately named
+  short-lived branch, commit there, push that branch to `origin`, then open a
+  PR into `main`.
+- If work begins on `main`, create the branch before making the task commit.
+- Before every push, inspect the destination ref and commits to be published.
+  Stop and ask for confirmation if the branch includes pre-existing or
+  unrelated commits.
+- A direct `origin/main` push requires explicit maintainer approval that names
+  `origin/main` after the agent has explained that it bypasses the PR workflow.
+- Never force-push or rewrite `main` without explicit maintainer approval.
+
 ## Validation
 
 Run the normal validation gate for source or test changes:


### PR DESCRIPTION
## Summary
- require task branches, branch pushes, and PRs for all normal changes
- make “commit and push” explicitly mean push the task branch, not `origin/main`
- require inspection and confirmation before publishing pre-existing or unrelated commits

## Validation
- `git diff --check origin/main...HEAD`

Personal global Claude preferences were updated separately and are not part of this repository PR.

## Summary by Sourcery

Documentation:
- Add a Git safety section to AGENTS.md describing required branch-based workflows, push practices, and approval rules for interacting with main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Git safety guidance covering short-lived branches, pull requests, pre-push checks, and approval requirements for changes to the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->