### PR TITLE
fix(benchmark): harden Hargreaves overhead gate

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,6 +33,7 @@ jobs:
             --benchmark-columns=mean,stddev,rounds
 
       - name: Upload benchmark results
+        if: ${{ !cancelled() }}  # preserve timing diagnostics when the benchmark gate fails
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results

--- a/tests/test_benchmark_overhead.py
+++ b/tests/test_benchmark_overhead.py
@@ -2,11 +2,13 @@
 Performance overhead benchmarks for xarray adapter layer.
 
 Validates FR-PERF-001 and NFR-PERF-001:
-- xarray path overhead threshold set to 80% vs NumPy path for 1D arrays
-- CI fails if benchmarks regress beyond threshold
+- xarray path overhead budget is 80% vs NumPy for most 1D operations
+- PET Hargreaves has a measured, operation-specific 100% budget
+- CI fails if benchmarks regress beyond the applicable budget
 
-Tests are marked with @pytest.mark.benchmark and excluded from default test runs.
-Run explicitly with: pytest -m benchmark --benchmark-enable
+Timed tests are marked with @pytest.mark.benchmark and excluded from default test
+runs; deterministic budget-policy tests run normally. Run timed tests explicitly
+with: pytest -m benchmark --benchmark-enable
 """
 
 from __future__ import annotations
@@ -26,12 +28,31 @@ from climate_indices.xarray_adapter import pet_hargreaves, pet_thornthwaite
 # measurement parameters for stable overhead measurement using timeit.repeat
 _OVERHEAD_REPEAT = 7  # independent trials (min filters CI noise)
 _OVERHEAD_NUMBER = 3  # calls per trial (amortizes per-call overhead)
-# overhead threshold: 80% accounts for xarray machinery overhead (apply_ufunc,
+# The shared 80% budget accounts for xarray machinery overhead (apply_ufunc,
 # coordinate handling, metadata propagation) on small 1D arrays. For gridded data
 # (the primary use case), this overhead is amortized across thousands of spatial
-# points and becomes negligible (<5%). Absolute performance remains fast
-# (sub-millisecond for these test cases).
-_OVERHEAD_THRESHOLD = 0.80  # 80%
+# points and becomes negligible (<5%).
+_OVERHEAD_THRESHOLD = 0.80
+# Unchanged GitHub-hosted runs measured PET Hargreaves overhead from 70.9% to
+# 85.7%. Its fast NumPy path makes the ratio unusually sensitive to fixed adapter
+# costs and runner noise. A 100% operation-specific budget adds 14.3 percentage
+# points of headroom above the observed maximum while still failing if the xarray
+# path takes twice as long as the equivalent NumPy path. See issue #740.
+_PET_HARGREAVES_OVERHEAD_THRESHOLD = 1.00
+
+
+def _assert_overhead_within_budget(
+    operation: str,
+    numpy_time: float,
+    xarray_time: float,
+    overhead: float,
+    budget: float,
+) -> None:
+    """Assert that measured xarray overhead is below an operation's budget."""
+    assert overhead < budget, (
+        f"{operation} xarray overhead {overhead:.1%} exceeds {budget:.0%} budget "
+        f"(numpy={numpy_time:.4f}s, xarray={xarray_time:.4f}s)"
+    )
 
 
 def _pet_hargreaves_numpy(
@@ -51,6 +72,38 @@ def _pet_hargreaves_numpy(
         daily_tmean_celsius=(daily_tmin_celsius + daily_tmax_celsius) / 2.0,
         latitude_degrees=latitude_degrees,
     )
+
+
+class TestOverheadBudgetPolicy:
+    """Test pass/fail policy without relying on wall-clock measurements."""
+
+    def test_pet_hargreaves_accepts_observed_ci_variation(self) -> None:
+        """The highest observed unchanged-run overhead retains noise headroom."""
+        numpy_time = 0.002
+        overhead = 0.857
+        xarray_time = numpy_time * (1.0 + overhead)
+
+        _assert_overhead_within_budget(
+            "PET Hargreaves",
+            numpy_time,
+            xarray_time,
+            overhead,
+            _PET_HARGREAVES_OVERHEAD_THRESHOLD,
+        )
+
+    def test_pet_hargreaves_rejects_material_slowdown_with_diagnostics(self) -> None:
+        """A material slowdown fails with both timings and the budget visible."""
+        with pytest.raises(AssertionError) as exc_info:
+            _assert_overhead_within_budget(
+                "PET Hargreaves",
+                numpy_time=0.002,
+                xarray_time=0.0044,
+                overhead=1.20,
+                budget=_PET_HARGREAVES_OVERHEAD_THRESHOLD,
+            )
+
+        expected_message = "PET Hargreaves xarray overhead 120.0% exceeds 100% budget (numpy=0.0020s, xarray=0.0044s)"
+        assert str(exc_info.value).splitlines()[0] == expected_message
 
 
 # ==============================================================================
@@ -228,9 +281,10 @@ class TestOverheadThreshold:
     - xarray apply_ufunc machinery (~0.2ms for PET functions)
     - Coordinate/metadata handling
 
-    Threshold set to 80% for 1D arrays. For gridded data (primary use case),
-    overhead is amortized across spatial dimensions and becomes negligible.
-    Absolute times remain fast (all operations <3ms for 40-year monthly or 5-year daily).
+    The shared budget is 80% for 1D arrays. PET Hargreaves uses its documented
+    operation-specific budget because fixed adapter costs and runner noise are
+    large relative to its fast NumPy baseline. For gridded data (primary use
+    case), overhead is amortized across spatial dimensions and becomes negligible.
 
     Uses timeit.repeat with min selection (standard Python benchmarking practice)
     to filter upward outliers from CI noise while catching real regressions.
@@ -281,10 +335,7 @@ class TestOverheadThreshold:
                 distribution=Distribution.gamma,
             ),
         )
-        assert overhead < _OVERHEAD_THRESHOLD, (
-            f"SPI xarray overhead {overhead:.1%} exceeds {_OVERHEAD_THRESHOLD:.0%} "
-            f"(numpy={np_time:.4f}s, xarray={xa_time:.4f}s)"
-        )
+        _assert_overhead_within_budget("SPI", np_time, xa_time, overhead, _OVERHEAD_THRESHOLD)
 
     def test_spei_overhead(
         self,
@@ -312,10 +363,7 @@ class TestOverheadThreshold:
                 distribution=Distribution.gamma,
             ),
         )
-        assert overhead < _OVERHEAD_THRESHOLD, (
-            f"SPEI xarray overhead {overhead:.1%} exceeds {_OVERHEAD_THRESHOLD:.0%} "
-            f"(numpy={np_time:.4f}s, xarray={xa_time:.4f}s)"
-        )
+        _assert_overhead_within_budget("SPEI", np_time, xa_time, overhead, _OVERHEAD_THRESHOLD)
 
     def test_pet_thornthwaite_overhead(
         self,
@@ -334,10 +382,7 @@ class TestOverheadThreshold:
                 latitude=40.0,
             ),
         )
-        assert overhead < _OVERHEAD_THRESHOLD, (
-            f"PET Thornthwaite xarray overhead {overhead:.1%} exceeds {_OVERHEAD_THRESHOLD:.0%} "
-            f"(numpy={np_time:.4f}s, xarray={xa_time:.4f}s)"
-        )
+        _assert_overhead_within_budget("PET Thornthwaite", np_time, xa_time, overhead, _OVERHEAD_THRESHOLD)
 
     def test_pet_hargreaves_overhead(
         self,
@@ -359,7 +404,10 @@ class TestOverheadThreshold:
                 latitude=40.0,
             ),
         )
-        assert overhead < _OVERHEAD_THRESHOLD, (
-            f"PET Hargreaves xarray overhead {overhead:.1%} exceeds {_OVERHEAD_THRESHOLD:.0%} "
-            f"(numpy={np_time:.4f}s, xarray={xa_time:.4f}s)"
+        _assert_overhead_within_budget(
+            "PET Hargreaves",
+            np_time,
+            xa_time,
+            overhead,
+            _PET_HARGREAVES_OVERHEAD_THRESHOLD,
         )

--- a/tests/test_benchmark_overhead.py
+++ b/tests/test_benchmark_overhead.py
@@ -50,7 +50,7 @@ def _assert_overhead_within_budget(
 ) -> None:
     """Assert that measured xarray overhead is below an operation's budget."""
     assert overhead < budget, (
-        f"{operation} xarray overhead {overhead:.1%} exceeds {budget:.0%} budget "
+        f"{operation} xarray overhead {overhead:.1%} meets or exceeds {budget:.0%} budget "
         f"(numpy={numpy_time:.4f}s, xarray={xarray_time:.4f}s)"
     )
 
@@ -102,7 +102,25 @@ class TestOverheadBudgetPolicy:
                 budget=_PET_HARGREAVES_OVERHEAD_THRESHOLD,
             )
 
-        expected_message = "PET Hargreaves xarray overhead 120.0% exceeds 100% budget (numpy=0.0020s, xarray=0.0044s)"
+        expected_message = (
+            "PET Hargreaves xarray overhead 120.0% meets or exceeds 100% budget (numpy=0.0020s, xarray=0.0044s)"
+        )
+        assert str(exc_info.value).splitlines()[0] == expected_message
+
+    def test_pet_hargreaves_rejects_overhead_at_budget(self) -> None:
+        """An overhead equal to the budget fails because the threshold is strict."""
+        with pytest.raises(AssertionError) as exc_info:
+            _assert_overhead_within_budget(
+                "PET Hargreaves",
+                numpy_time=0.002,
+                xarray_time=0.004,
+                overhead=_PET_HARGREAVES_OVERHEAD_THRESHOLD,
+                budget=_PET_HARGREAVES_OVERHEAD_THRESHOLD,
+            )
+
+        expected_message = (
+            "PET Hargreaves xarray overhead 100.0% meets or exceeds 100% budget (numpy=0.0020s, xarray=0.0040s)"
+        )
         assert str(exc_info.value).splitlines()[0] == expected_message
 
 


### PR DESCRIPTION
## Summary

- give PET Hargreaves a documented 100% operation-specific overhead budget based on observed hosted-runner variance
- add deterministic tests for accepted variance, material regressions, and failure diagnostics
- preserve pytest-benchmark JSON artifacts when the performance gate fails

Closes #740

## Validation

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uv run pytest`
- `uv run pytest -m benchmark --benchmark-enable --benchmark-json=/tmp/climate-indices-issue-740-benchmark-results.json --benchmark-columns=mean,stddev,rounds`

## Summary by Sourcery

Adjust performance overhead gating for PET Hargreaves and related benchmarks to better account for hosted-runner variance while improving diagnostics and policy coverage.

CI:
- Update the benchmarks workflow to always upload benchmark timing artifacts even when the performance gate fails, preserving diagnostics for regressions.

Tests:
- Add deterministic tests that validate PET Hargreaves’ operation-specific overhead budget and assert both accepted variance and failure diagnostics.
- Refactor existing overhead benchmark tests to use a shared assertion helper and clarify the distinction between timed benchmark tests and deterministic policy tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark results are now uploaded even when performance checks fail, unless the workflow is cancelled.

* **Tests**
  * Improved benchmark validation with clearer timing diagnostics and deterministic checks.
  * Added coverage for expected performance variation and meaningful slowdowns across supported calculations.

* **Documentation**
  * Clarified shared and operation-specific performance budgets.
  * Documented how to run benchmark tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->