### PR TITLE
fix: reject fractional window_length and incomplete windows

### DIFF
--- a/src/climate_indices/self_calibration.py
+++ b/src/climate_indices/self_calibration.py
@@ -23,7 +23,7 @@ from collections import deque
 
 import numpy as np
 
-from climate_indices.exceptions import InvalidArgumentError
+from climate_indices.exceptions import InsufficientDataError, InvalidArgumentError
 
 __all__ = [
     "DRY_SIGN",
@@ -207,15 +207,19 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int, sign: int) -> float:
 
     Returns:
         The representative extreme rolling sum for this window length. On the
-        wet side this is 0.0 when no rolling sum survives the anomaly filter,
-        or when the series has fewer than ``window_length`` non-missing
-        values and no complete window ever forms. On the dry side the latter
-        case returns NaN instead, since the dry path has no 0.0 floor to fall
-        back on.
+        wet side this is 0.0 when no rolling sum survives the anomaly filter
+        (see :func:`_highest_reasonable`); that 0.0 is a real result of the
+        published algorithm, not a placeholder.
 
     Raises:
         InvalidArgumentError: If sign is invalid or window_length is not a
             positive integer.
+        InsufficientDataError: If ``z_values`` has fewer than ``window_length``
+            non-missing values, so no complete window ever forms. There is no
+            safe sentinel for this case: a 0.0 would be indistinguishable from
+            the wet-side anomaly-filter floor above, and a NaN would silently
+            satisfy :func:`duration_factors`' documented ``m + b <= 0`` guard
+            instead of tripping it.
     """
     _validate_sign(sign)
     if window_length < 1 or not float(window_length).is_integer():
@@ -240,10 +244,18 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int, sign: int) -> float:
             window.append(value)
 
     if len(window) < window_length:
-        # the series ended before a complete window could be formed, so there
-        # is no rolling sum to report -- not even the partial one just
-        # accumulated, which would be a shorter-than-window_length sum
-        return 0.0 if sign == WET_SIGN else float("nan")
+        # the series ended before a complete window could be formed. There is
+        # no safe sentinel to report here -- not even the partial sum just
+        # accumulated, which would be a shorter-than-window_length sum -- since
+        # a 0.0/NaN placeholder is indistinguishable from a legitimate result
+        # downstream (0.0 collides with the wet-side anomaly-filter floor, and
+        # NaN silently satisfies duration_factors' documented `m + b <= 0`
+        # guard instead of tripping it). Raise instead of guessing.
+        raise InsufficientDataError(
+            f"no complete {window_length}-period rolling window: only {len(window)} non-missing periods were available",
+            non_zero_count=len(window),
+            required_count=window_length,
+        )
 
     extreme = running
     sums = np.empty(series.size + 1, dtype=float)
@@ -411,6 +423,10 @@ def duration_factors(z_values: np.ndarray, sign: int) -> tuple[float, float]:
 
     Raises:
         InvalidArgumentError: If sign is invalid.
+        InsufficientDataError: If the calibration period is too short, or has
+            too many missing values, for the largest window length in
+            :data:`DURATION_FACTOR_WINDOW_LENGTHS` to ever complete -- see
+            :func:`extreme_z_sum`.
     """
     _validate_sign(sign)
 

--- a/src/climate_indices/self_calibration.py
+++ b/src/climate_indices/self_calibration.py
@@ -207,13 +207,18 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int, sign: int) -> float:
 
     Returns:
         The representative extreme rolling sum for this window length. On the
-        wet side this is 0.0 when no rolling sum survives the anomaly filter.
+        wet side this is 0.0 when no rolling sum survives the anomaly filter,
+        or when the series has fewer than ``window_length`` non-missing
+        values and no complete window ever forms. On the dry side the latter
+        case returns NaN instead, since the dry path has no 0.0 floor to fall
+        back on.
 
     Raises:
-        InvalidArgumentError: If sign is invalid or window_length is not positive.
+        InvalidArgumentError: If sign is invalid or window_length is not a
+            positive integer.
     """
     _validate_sign(sign)
-    if window_length < 1:
+    if window_length < 1 or not float(window_length).is_integer():
         raise InvalidArgumentError(
             f"invalid rolling window length: {window_length}",
             argument_name="window_length",
@@ -233,6 +238,12 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int, sign: int) -> float:
         if not math.isnan(value):
             running += value
             window.append(value)
+
+    if len(window) < window_length:
+        # the series ended before a complete window could be formed, so there
+        # is no rolling sum to report -- not even the partial one just
+        # accumulated, which would be a shorter-than-window_length sum
+        return 0.0 if sign == WET_SIGN else float("nan")
 
     extreme = running
     sums = np.empty(series.size + 1, dtype=float)

--- a/tests/test_self_calibration.py
+++ b/tests/test_self_calibration.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 from climate_indices import self_calibration
-from climate_indices.exceptions import InvalidArgumentError
+from climate_indices.exceptions import InsufficientDataError, InvalidArgumentError
 
 
 class TestKthSmallest:
@@ -144,41 +144,48 @@ class TestExtremeZSum:
     def test_rejects_a_fractional_window_length(self):
         z = np.arange(10.0)
 
-        with pytest.raises(InvalidArgumentError):
+        with pytest.raises(InvalidArgumentError) as exc_info:
             self_calibration.extreme_z_sum(z, 2.5, self_calibration.WET_SIGN)
 
-    def test_wet_side_floors_to_zero_when_series_is_shorter_than_one_window(self):
-        # only 2 non-missing values are available, so a 5-period window can
-        # never fully form -- the partial 2-period sum must not be used as a
-        # stand-in candidate
+        assert exc_info.value.argument_name == "window_length"
+        assert exc_info.value.argument_value == "2.5"
+        assert exc_info.value.valid_values == "a positive integer"
+
+    def test_accepts_an_integer_valued_float_window_length(self):
+        # window_length is deliberately checked with float(x).is_integer()
+        # rather than isinstance(x, int), so an integer-valued float like 2.0
+        # must still be accepted, not just rejected when fractional
         z = np.array([1.0, 2.0])
 
-        result = self_calibration.extreme_z_sum(z, 5, self_calibration.WET_SIGN)
+        result = self_calibration.extreme_z_sum(z, 2.0, self_calibration.WET_SIGN)
 
-        assert result == pytest.approx(0.0)
+        assert result == pytest.approx(3.0)
 
-    def test_dry_side_returns_nan_when_series_is_shorter_than_one_window(self):
-        z = np.array([-1.0, -2.0])
+    @pytest.mark.parametrize("sign", [self_calibration.WET_SIGN, self_calibration.DRY_SIGN])
+    def test_raises_insufficient_data_when_series_is_shorter_than_one_window(self, sign):
+        # only 2 non-missing values are available, so a 5-period window can
+        # never fully form on either side -- there is no sentinel value that
+        # safely stands in for "no complete window was ever seen", so this
+        # must raise rather than return a floor/NaN placeholder
+        z = np.array([1.0, 2.0])
 
-        result = self_calibration.extreme_z_sum(z, 5, self_calibration.DRY_SIGN)
+        with pytest.raises(InsufficientDataError) as exc_info:
+            self_calibration.extreme_z_sum(z, 5, sign)
 
-        assert np.isnan(result)
+        assert exc_info.value.non_zero_count == 2
+        assert exc_info.value.required_count == 5
 
-    def test_wet_side_floors_to_zero_when_missing_values_prevent_a_full_window(self):
+    @pytest.mark.parametrize("sign", [self_calibration.WET_SIGN, self_calibration.DRY_SIGN])
+    def test_raises_insufficient_data_when_missing_values_prevent_a_full_window(self, sign):
         # 3 non-missing values total, none of which can ever fill a 5-period
-        # window even though the raw series is longer than 5 entries
+        # window even though the raw series has 5 entries
         z = np.array([1.0, np.nan, 2.0, np.nan, 3.0])
 
-        result = self_calibration.extreme_z_sum(z, 5, self_calibration.WET_SIGN)
+        with pytest.raises(InsufficientDataError) as exc_info:
+            self_calibration.extreme_z_sum(z, 5, sign)
 
-        assert result == pytest.approx(0.0)
-
-    def test_dry_side_returns_nan_when_missing_values_prevent_a_full_window(self):
-        z = np.array([-1.0, np.nan, -2.0, np.nan, -3.0])
-
-        result = self_calibration.extreme_z_sum(z, 5, self_calibration.DRY_SIGN)
-
-        assert np.isnan(result)
+        assert exc_info.value.non_zero_count == 3
+        assert exc_info.value.required_count == 5
 
     def test_wet_side_returns_the_largest_survivor_rather_than_the_threshold(self):
         z = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 11.0])

--- a/tests/test_self_calibration.py
+++ b/tests/test_self_calibration.py
@@ -141,6 +141,45 @@ class TestExtremeZSum:
         with pytest.raises(InvalidArgumentError):
             self_calibration.extreme_z_sum(z, 0, self_calibration.WET_SIGN)
 
+    def test_rejects_a_fractional_window_length(self):
+        z = np.arange(10.0)
+
+        with pytest.raises(InvalidArgumentError):
+            self_calibration.extreme_z_sum(z, 2.5, self_calibration.WET_SIGN)
+
+    def test_wet_side_floors_to_zero_when_series_is_shorter_than_one_window(self):
+        # only 2 non-missing values are available, so a 5-period window can
+        # never fully form -- the partial 2-period sum must not be used as a
+        # stand-in candidate
+        z = np.array([1.0, 2.0])
+
+        result = self_calibration.extreme_z_sum(z, 5, self_calibration.WET_SIGN)
+
+        assert result == pytest.approx(0.0)
+
+    def test_dry_side_returns_nan_when_series_is_shorter_than_one_window(self):
+        z = np.array([-1.0, -2.0])
+
+        result = self_calibration.extreme_z_sum(z, 5, self_calibration.DRY_SIGN)
+
+        assert np.isnan(result)
+
+    def test_wet_side_floors_to_zero_when_missing_values_prevent_a_full_window(self):
+        # 3 non-missing values total, none of which can ever fill a 5-period
+        # window even though the raw series is longer than 5 entries
+        z = np.array([1.0, np.nan, 2.0, np.nan, 3.0])
+
+        result = self_calibration.extreme_z_sum(z, 5, self_calibration.WET_SIGN)
+
+        assert result == pytest.approx(0.0)
+
+    def test_dry_side_returns_nan_when_missing_values_prevent_a_full_window(self):
+        z = np.array([-1.0, np.nan, -2.0, np.nan, -3.0])
+
+        result = self_calibration.extreme_z_sum(z, 5, self_calibration.DRY_SIGN)
+
+        assert np.isnan(result)
+
     def test_wet_side_returns_the_largest_survivor_rather_than_the_threshold(self):
         z = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 11.0])
 


### PR DESCRIPTION
## Summary
- `extreme_z_sum()` accepted fractional `window_length` values (e.g. `2.5`); now rejects any non-integer.
- The initial rolling-window fill could reach end-of-series with fewer than `window_length` non-missing values and still treat that partial sum as a valid candidate. Now returns `0.0` on the wet side (matching the existing "nothing survives" floor) and `NaN` on the dry side (matching this module's missing-data convention) when no complete window ever forms.

Addresses outstanding review feedback on #742.

## Test plan
- [x] `uv run pytest tests/test_self_calibration.py -v` — 46 passed, including 6 new tests (fractional window_length rejection, wet/dry short-series, wet/dry missing-values-prevent-full-window)
- [x] `uv run pytest` — 1107 passed
- [x] `uv run ruff check --fix src/climate_indices/self_calibration.py tests/test_self_calibration.py` — clean

## Summary by Sourcery

Enforce stricter validation and behavior in extreme_z_sum for invalid window lengths and incomplete rolling windows.

Bug Fixes:
- Reject non-integer window_length values passed to extreme_z_sum.
- Return 0.0 on the wet side and NaN on the dry side when no complete rolling window can be formed due to short series or missing values.

Tests:
- Add unit tests covering fractional window_length rejection and wet/dry behavior when the series or available non-missing values are insufficient to form a full window.