### PR TITLE
fix: align rolling-window types with accepted inputs

### DIFF
--- a/src/climate_indices/self_calibration.py
+++ b/src/climate_indices/self_calibration.py
@@ -183,7 +183,7 @@ def _highest_reasonable(sums: np.ndarray, sign: int) -> float:
     return highest
 
 
-def extreme_z_sum(z_values: np.ndarray, window_length: int, sign: int) -> float:
+def extreme_z_sum(z_values: np.ndarray, window_length: int | float, sign: int) -> float:
     """Compute the representative extreme rolling Z-index sum for one window length.
 
     Ports ``get_Z_sum()``. Slides a window of ``window_length`` non-missing

--- a/src/climate_indices/self_calibration.py
+++ b/src/climate_indices/self_calibration.py
@@ -203,6 +203,7 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int | float, sign: int) -
     Args:
         z_values: The Z-index series, in chronological order; NaN means missing.
         window_length: The number of non-missing periods in the rolling window.
+            Integer-valued floats such as 5.0 are accepted.
         sign: WET_SIGN or DRY_SIGN.
 
     Returns:
@@ -213,7 +214,7 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int | float, sign: int) -
 
     Raises:
         InvalidArgumentError: If sign is invalid or window_length is not a
-            positive integer.
+            positive integer or integer-valued float.
         InsufficientDataError: If ``z_values`` has fewer than ``window_length``
             non-missing values, so no complete window ever forms. There is no
             safe sentinel for this case: a 0.0 would be indistinguishable from
@@ -227,7 +228,7 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int | float, sign: int) -
             f"invalid rolling window length: {window_length}",
             argument_name="window_length",
             argument_value=str(window_length),
-            valid_values="a positive integer",
+            valid_values="a positive integer or integer-valued float",
         )
     window_length = int(window_length)
 

--- a/src/climate_indices/self_calibration.py
+++ b/src/climate_indices/self_calibration.py
@@ -229,6 +229,7 @@ def extreme_z_sum(z_values: np.ndarray, window_length: int | float, sign: int) -
             argument_value=str(window_length),
             valid_values="a positive integer",
         )
+    window_length = int(window_length)
 
     series = np.asarray(z_values, dtype=float)
     window: deque[float] = deque()

--- a/tests/test_self_calibration.py
+++ b/tests/test_self_calibration.py
@@ -161,7 +161,7 @@ class TestExtremeZSum:
 
         assert result == pytest.approx(3.0)
 
-    def test_integer_valued_float_window_length_is_normalized_in_error_metadata(self):
+    def test_extreme_z_sum_normalizes_integer_valued_float_in_error_metadata(self):
         z = np.array([1.0, 2.0])
 
         with pytest.raises(InsufficientDataError) as exc_info:

--- a/tests/test_self_calibration.py
+++ b/tests/test_self_calibration.py
@@ -161,6 +161,15 @@ class TestExtremeZSum:
 
         assert result == pytest.approx(3.0)
 
+    def test_integer_valued_float_window_length_is_normalized_in_error_metadata(self):
+        z = np.array([1.0, 2.0])
+
+        with pytest.raises(InsufficientDataError) as exc_info:
+            self_calibration.extreme_z_sum(z, 5.0, self_calibration.WET_SIGN)
+
+        assert exc_info.value.required_count == 5
+        assert isinstance(exc_info.value.required_count, int)
+
     @pytest.mark.parametrize("sign", [self_calibration.WET_SIGN, self_calibration.DRY_SIGN])
     def test_raises_insufficient_data_when_series_is_shorter_than_one_window(self, sign):
         # only 2 non-missing values are available, so a 5-period window can

--- a/tests/test_self_calibration.py
+++ b/tests/test_self_calibration.py
@@ -149,7 +149,7 @@ class TestExtremeZSum:
 
         assert exc_info.value.argument_name == "window_length"
         assert exc_info.value.argument_value == "2.5"
-        assert exc_info.value.valid_values == "a positive integer"
+        assert exc_info.value.valid_values == "a positive integer or integer-valued float"
 
     def test_accepts_an_integer_valued_float_window_length(self):
         # window_length is deliberately checked with float(x).is_integer()


### PR DESCRIPTION
## Summary

- Widen `extreme_z_sum()` window-length typing to match its existing support for integer-valued floats such as `5.0`.
- Normalize validated window lengths to `int` before rolling-window processing and error reporting.
- Add a regression test ensuring `InsufficientDataError.required_count` remains an integer.

## Why

The function already accepts integer-valued floats at runtime, but its annotation only allowed `int`. Widening the annotation exposed a type-checking mismatch when the value was passed to `InsufficientDataError`. Normalizing after validation keeps the public contract, internal processing, and exception metadata consistent.

This is a focused follow-up to #746 and targets the feature branch used by #742.

## Testing

RED evidence:

- `uv run mypy src/climate_indices/self_calibration.py` reported `required_count` as `int | float` where `int | None` is required.
- The new regression test failed because `required_count` was `5.0` instead of an `int`.

GREEN evidence:

- `uv run pytest tests/test_self_calibration.py -q` — 48 passed
- `uv run mypy src/climate_indices/self_calibration.py` — no issues found
- `uv run ruff check src/climate_indices/self_calibration.py tests/test_self_calibration.py` — passed
- `uv run ruff format --check src/climate_indices/self_calibration.py tests/test_self_calibration.py` — passed

## Summary by Sourcery

Align rolling-window error handling and types with support for integer-valued float window lengths.

Bug Fixes:
- Ensure integer-valued float window lengths are normalized to integers in rolling-window error metadata to keep InsufficientDataError.required_count typed as int.

Enhancements:
- Widen extreme_z_sum() window_length typing to accept integer-valued floats consistent with existing runtime behavior.

Tests:
- Add a regression test verifying integer-valued float window lengths yield an int required_count in InsufficientDataError.