### PR TITLE
docs: record architecture deepening review

### DIFF
--- a/.handoffs/xarray-calendar-semantics-2026-08-27T114920Z.md
+++ b/.handoffs/xarray-calendar-semantics-2026-08-27T114920Z.md
@@ -1,0 +1,87 @@
+# Handoff: xarray calendar semantics
+
+## Objective
+
+Continue the top architecture recommendation on a dedicated implementation branch: make calendar semantics explicit at the xarray seam, with an eventual pull request after the architecture findings PR is merged or used as the stacked base.
+
+## Completed
+
+- Created the clean worktree and `chore/architecture-cleanup` branch from `origin/main`.
+- Ran the `improve-codebase-architecture` exploration against the domain context and all ADRs.
+- Published the durable findings in [`docs/architecture-deepening-review-2026-08-27.md`](../docs/architecture-deepening-review-2026-08-27.md).
+- Opened [PR #753](https://github.com/monocongo/climate_indices/pull/753) for the findings.
+- Selected “Make calendar semantics explicit at the xarray seam” as the implementation focus.
+
+Do not duplicate the findings in this handoff; read the review document for evidence, candidate details, and secondary observations.
+
+## Branch strategy
+
+- Findings PR branch: `chore/architecture-cleanup`
+- Implementation branch: `fix/xarray-calendar-semantics`
+- The implementation branch is intentionally created from the findings branch so this handoff and review remain available.
+- After PR #753 merges, rebase the implementation branch onto updated `origin/main` before opening its pull request. If work must be reviewed earlier, use PR #753 as the temporary stacked base.
+- Do not modify the separate original worktree, which contains unrelated uncommitted work.
+
+## Required reading
+
+1. [`docs/architecture-deepening-review-2026-08-27.md`](../docs/architecture-deepening-review-2026-08-27.md), especially candidate 1.
+2. [`src/climate_indices/CONTEXT.md`](../src/climate_indices/CONTEXT.md).
+3. [`docs/adr/0001-dual-numpy-xarray-api.md`](../docs/adr/0001-dual-numpy-xarray-api.md).
+4. [`docs/adr/0002-multiprocessing-cli-dask-xarray.md`](../docs/adr/0002-multiprocessing-cli-dask-xarray.md).
+5. [`docs/adr/0003-dask-time-dimension-single-chunk.md`](../docs/adr/0003-dask-time-dimension-single-chunk.md).
+6. Relevant implementations in `xarray_adapter.py`, `utils.py`, `indices.py`, and `eto.py`.
+
+## Current technical state
+
+- `_infer_periodicity()` accepts ordinary daily Gregorian coordinates.
+- Generic xarray adaptation then sends raw values to NumPy implementations.
+- Daily NumPy computation groups values into fixed 366-day positional years, so non-leap years shift later calendar positions.
+- Monthly NumPy computation assumes the first value is January, while the xarray seam currently accepts regular monthly coordinates beginning in another month.
+- The CLI already uses `utils.transform_to_366day()` before computation and `utils.transform_to_gregorian()` afterward.
+- `transform_to_366day()` assumes a January 1 start and full years except a possible partial final year; for non-leap years it synthesizes February 29 as the mean of February 28 and March 1.
+- The xarray result restores original coordinates after computation, which can hide positional drift.
+- No source implementation has been changed yet.
+
+## Design questions to resolve in the grilling loop
+
+Do not propose or implement an interface until these choices are explicit:
+
+1. Is the first implementation limited to standard/proleptic Gregorian datetime coordinates, or must it support cftime calendars now?
+2. Should monthly input beginning after January be rejected or internally padded to a January origin and restored afterward?
+3. Should daily input beginning after January 1 be rejected or normalized as a partial first year?
+4. Must partial final years remain supported exactly as today?
+5. Should the xarray module reuse the current NumPy calendar transformations or own coordinate-aware transformations that remain lazy for Dask?
+6. How will synthetic February 29 values interact with missing-data propagation and Timescale windows?
+7. Which public computations enter the first vertical slice: SPI only, all generic index adapters, or generic indices plus both PET methods?
+
+## Suggested first vertical slice
+
+After grilling, start with a daily SPI regression through the public xarray interface:
+
+- Use at least one non-leap year followed by a leap year.
+- Compare against explicit `transform_to_366day()` → stable NumPy SPI → `transform_to_gregorian()` behavior.
+- Assert original time coordinates and dimension order are preserved.
+- Repeat for eager and Dask-backed inputs while retaining the one-time-chunk invariant.
+- Add monthly non-January-origin behavior as a separate test once reject-versus-normalize is decided.
+
+Then generalize only through the shared xarray seam so SPEI, EDDI, and PNP gain leverage without editing each caller. Treat PET as a follow-up slice if its calendar needs differ.
+
+## Validation gate
+
+For source or test changes run:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+uv run pytest
+```
+
+Run focused tests throughout development, but complete the full gate before the eventual pull request.
+
+## Suggested skills
+
+- **improve-codebase-architecture** — continue its required grilling loop and preserve the module/interface/seam vocabulary.
+- **tdd** — establish daily Gregorian and monthly-origin regressions before changing adaptation.
+- **diagnose** — minimize and instrument any mismatch between explicit CLI-style conversion and xarray results.
+- **code-review** — review the final branch against repository standards, ADRs, and the selected recommendation before opening the eventual pull request.

--- a/docs/architecture-deepening-review-2026-08-27.md
+++ b/docs/architecture-deepening-review-2026-08-27.md
@@ -1,0 +1,241 @@
+# Architecture Deepening Review — 2026-08-27
+
+## Scope
+
+This review applied the deletion test to the current `climate_indices` source tree, using the domain language in [`src/climate_indices/CONTEXT.md`](../src/climate_indices/CONTEXT.md) and the decisions in [`docs/adr/`](./adr/).
+
+The aim is to increase **depth**: more leverage through smaller interfaces and more locality inside implementations. This document records candidates, not proposed interfaces.
+
+## Recommendation summary
+
+| Strength | Candidate | Primary modules |
+|---|---|---|
+| **Strong** | Make calendar semantics explicit at the xarray seam | `xarray_adapter.py`, `utils.py`, `indices.py`, `eto.py` |
+| **Strong** | Collapse duplicated CLI preparation and transport | `__main__.py`, `__spi__.py` |
+| **Worth exploring** | Concentrate Distribution Fitting policy | `compute.py`, `indices.py`, `lmoments.py`, `__spi__.py` |
+| **Strong** | Use one Output Provenance finalizer | `xarray_adapter.py`, `typed_public_api.py`, `cf_metadata_registry.py` |
+| **Strong** | Own multi-input alignment at one seam | `xarray_adapter.py` |
+| **Worth exploring** | Deepen the Palmer computation state | `palmer.py` |
+
+## 1. Make calendar semantics explicit at the xarray seam
+
+**Files**
+
+- `src/climate_indices/xarray_adapter.py`
+- `src/climate_indices/utils.py`
+- `src/climate_indices/indices.py`
+- `src/climate_indices/eto.py`
+- `src/climate_indices/__main__.py`
+- `src/climate_indices/__spi__.py`
+- `tests/test_xarray_adapter.py`
+- `tests/test_xarray_equivalence.py`
+
+**Problem**
+
+The xarray interface infers daily Periodicity from ordinary Gregorian coordinates, then passes raw values to NumPy implementations that group every year into 366 positional values. Non-leap years therefore shift calendar positions. Monthly coordinates can likewise begin after January even though the NumPy implementation assumes a January-first series. Original coordinates are attached to the result, hiding the positional drift.
+
+The CLI already owns explicit Gregorian-to-366-day and 366-day-to-Gregorian conversion, but that calendar knowledge does not protect the xarray seam.
+
+**Deepening direction**
+
+Concentrate calendar validation, conversion, and coordinate restoration inside xarray adaptation. Preserve the stable NumPy implementation required by [ADR-0001](./adr/0001-dual-numpy-xarray-api.md), and do not combine the distinct execution implementations protected by [ADR-0002](./adr/0002-multiprocessing-cli-dask-xarray.md).
+
+**Benefits**
+
+- Locality: one calendar policy.
+- Leverage: SPI, SPEI, EDDI, PNP, and PET use it.
+- Tests cross the same seam as callers.
+- Coordinate labels remain truthful.
+
+**Tests to add before implementation**
+
+- Daily Gregorian xarray results match explicit 366-day NumPy computation after restoration.
+- Non-leap February does not shift March–December values.
+- Leap and non-leap multi-year inputs retain their original time coordinates.
+- Monthly and daily inputs with unsupported start positions fail explicitly rather than silently drifting.
+- Eager and Dask-backed inputs behave equivalently while preserving [ADR-0003](./adr/0003-dask-time-dimension-single-chunk.md).
+
+**Recommendation strength: Strong.** This is the top recommendation because one deep module prevents silent scientific misalignment across several public computations without changing the stable NumPy interface.
+
+## 2. Collapse duplicated CLI preparation and transport
+
+**Files**
+
+- `src/climate_indices/__main__.py`
+- `src/climate_indices/__spi__.py`
+- `tests/test_input_validation.py`
+- `tests/test_main_palmers.py`
+
+**Problem**
+
+Both commands duplicate dimension policy, daily conversion, shared-memory allocation, worker initialization, and multiprocessing partitioning. Both `_prepare_file` implementations claim to reorder dimensions but only compare dimension sets and return the original path. Later code accepts a different set of dimension orders, so the apparent preparation seam is shallow.
+
+**Deepening direction**
+
+A private deep module should own accepted layouts, normalization, daily conversion, partitioning, and shared-memory transport. Command-specific computation and SPI parameter persistence remain separate.
+
+**Benefits**
+
+- Locality: dimension policy lives in one module.
+- Leverage: both commands share transport fixes.
+- Duplicate mechanics can be deleted.
+- Preparation tests exercise truthful behavior.
+
+**Decision fit**
+
+This preserves ADR-0002: multiprocessing remains the CLI execution implementation and Dask remains the xarray execution implementation.
+
+**Recommendation strength: Strong.**
+
+## 3. Concentrate Distribution Fitting policy
+
+**Files**
+
+- `src/climate_indices/compute.py`
+- `src/climate_indices/indices.py`
+- `src/climate_indices/lmoments.py`
+- `src/climate_indices/__spi__.py`
+- `tests/test_compute.py`
+- `tests/test_indices.py`
+- `tests/test_zero_precipitation_fix.py`
+
+**Problem**
+
+Calibration Period selection, Probability of Zero, Gamma and Pearson parameter representation, fallback, diagnostics, compatibility translation, and CLI persistence knowledge are distributed across callers.
+
+Observed policy differences include:
+
+- Gamma parameters use Calibration Period data while Gamma Probability of Zero currently uses the whole record.
+- Pearson counts non-zero calibration values but passes the zero-inclusive sample to L-Moments fitting.
+- SPI and SPEI do not apply fitted-parameter compatibility translation consistently.
+- The CLI knows every distribution-specific parameter field and storage arrangement.
+- End-year calculations and minimum Calibration Period behavior are not expressed consistently in every path.
+
+**Deepening direction**
+
+Concentrate scientific policy in one internal Distribution Fitting module while preserving legacy NumPy call forms as compatibility adapters.
+
+**Benefits**
+
+- Locality: scientific policy and diagnostics concentrate.
+- Leverage: Gamma and Pearson share calibration behavior.
+- One interface becomes the fitting test surface.
+- Compatibility knowledge stops leaking into callers.
+
+**Risk**
+
+Resolving current differences may intentionally change scientific outputs. Lock existing fixtures first, isolate policy decisions, and require explicit approval for output changes.
+
+**Recommendation strength: Worth exploring.**
+
+## 4. Use one Output Provenance finalizer
+
+**Files**
+
+- `src/climate_indices/xarray_adapter.py`
+- `src/climate_indices/typed_public_api.py`
+- `src/climate_indices/cf_metadata_registry.py`
+- `tests/test_metadata_validation.py`
+- `tests/test_pci_xarray.py`
+- `tests/test_xarray_adapter.py`
+
+**Problem**
+
+Output Provenance and CF metadata are one domain behavior with three implementations:
+
+- Decorated index paths preserve source attributes, apply CF and calculation metadata, add the version, and append history.
+- PET paths reproduce much of that implementation separately.
+- PCI drops source attributes and prior history, then creates a differently formatted history value.
+
+Computation shape currently determines provenance semantics.
+
+**Deepening direction**
+
+Route every xarray result shape through one deep finalization module without forcing scalar, time-series, and spatial computation paths to become identical.
+
+**Benefits**
+
+- Locality: Output Provenance policy concentrates.
+- Leverage: every xarray result uses one implementation.
+- Tests cross one interface.
+- Shape differences remain implementation details.
+
+**Recommendation strength: Strong.**
+
+## 5. Own multi-input alignment at one seam
+
+**Files**
+
+- `src/climate_indices/xarray_adapter.py`
+- `tests/test_xarray_adapter.py`
+- `tests/test_xarray_equivalence.py`
+
+**Problem**
+
+Generic multi-input alignment uses `xr.align(..., join="inner")` across every shared coordinate but reports only dropped primary time values. Shared latitude or longitude values can be intersected without equivalent diagnostics. Validation and Dask chunk checks focus on the primary input. Hargreaves PET implements a separate alignment path with different warning context.
+
+Two current adapters—SPEI and Hargreaves PET—make this a real seam rather than a hypothetical one.
+
+**Deepening direction**
+
+One deep alignment module should own coordinate-loss policy, validation of every input, Dask constraints, and structured diagnostics.
+
+**Benefits**
+
+- Locality: alignment policy concentrates.
+- Leverage: two current adapters and future multi-input indices.
+- Secondary-input invariants become explicit.
+- Tests cover every aligned coordinate.
+
+**Recommendation strength: Strong.**
+
+## 6. Deepen the Palmer computation state
+
+**Files**
+
+- `src/climate_indices/palmer.py`
+- `tests/test_palmer.py`
+- `tests/test_palmer_duration_factors.py`
+- `tests/test_property_based.py`
+
+**Problem**
+
+A mutable `dict[str, Any]` containing more than thirty keys is the hidden interface among Palmer phases. Key names, shapes, initialization order, mutation order, and phase order are spread across more than twenty helpers. Tests reconstruct the water-balance, CAFEC, K-Factor, and recurrence sequence to inject duration factors.
+
+**Deepening direction**
+
+Make state ownership and phase ordering local to the Palmer module while preserving arithmetic order and the public `pdsi` interface.
+
+**Benefits**
+
+- Locality: state schema and ordering concentrate.
+- The public interface stays stable.
+- Phase tests stop reconstructing implementation order.
+- Numerical invariants become visible.
+
+**Risk**
+
+This is numerically sensitive code. Preserve arithmetic order, NOAA fixtures, and standard Palmer behavior. Do not introduce scPDSI or a Palmer xarray interface during this cleanup.
+
+**Recommendation strength: Worth exploring.**
+
+## Additional observations
+
+These did not outrank the six candidates but should remain visible for later review:
+
+- `eto.eto_thornthwaite()` mutates caller-owned temperature arrays; the xarray PET adapter compensates with copies. A non-mutating ETo implementation would remove leaked ownership knowledge and per-cell defensive copies.
+- `compute.scale_values()` is a shallow Timescale-preparation seam used by the specialized CLI while SPI, SPEI, EDDI, and PNP repeat related preparation knowledge.
+- Lifecycle logging can occur once per spatial cell when xarray vectorization calls legacy NumPy functions; event cardinality and host-application logger configuration need explicit policy.
+- Several metadata entries, exception types, and pattern-compliance claims have no production callers or conflict with ADR-0001’s Palmer decision. Public compatibility must be checked before deletion.
+- Four-channel Palmer output knowledge is repeated across CLI allocation, worker writes, conversion, metadata, and persistence.
+- `self_calibration.py` is well tested but has no production caller while scPDSI remains explicitly unimplemented; retain it only with clear staged-work ownership.
+- `pm_eto.py` currently exposes low-level equation helpers without an in-repository computation caller. Confirm intended product scope before deepening or removing it.
+
+## Suggested order
+
+1. Make calendar semantics explicit at the xarray seam.
+2. Use one Output Provenance finalizer.
+3. Own multi-input alignment at one seam.
+4. Collapse duplicated CLI preparation and transport.
+5. Explore Distribution Fitting policy under fixture locks.
+6. Explore Palmer state under numerical regression locks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ This documentation set is optimized for AI agents and provides comprehensive tec
    - Data flow and computation patterns
    - Testing architecture and CI/CD pipelines
    - Key design decisions and trade-offs
+   - Current deepening candidates: [architecture-deepening-review-2026-08-27.md](./architecture-deepening-review-2026-08-27.md)
 
 3. **[source-tree-analysis.md](./source-tree-analysis.md)** 🟡 HIGH PRIORITY
    - Annotated directory structure


### PR DESCRIPTION
## Summary

- record six architecture deepening candidates grounded in the project domain language and ADRs
- identify calendar semantics at the xarray seam as the top recommendation
- retain additional lower-priority observations for later reviews
- link the review from the documentation index

## Top recommendation

Concentrate calendar validation, Gregorian-to-366-day conversion, and coordinate restoration inside xarray adaptation while preserving the stable NumPy computation interface and the existing CLI/Dask execution decisions.

## Validation

- `git diff --check`
- documentation structure and repository-relative link checks

No source or test behavior changes are included.

## Summary by Sourcery

Record the architecture deepening review and prepare follow-up work for calendar handling at the xarray boundary.

New Features:
- Document six architecture-deepening candidates, including a top recommendation to make calendar semantics explicit at the xarray seam.

Enhancements:
- Capture architectural findings, trade-offs, risks, and a suggested order for future implementation work.
- Provide a handoff for the planned xarray calendar-semantics implementation, including design questions and validation guidance.

Documentation:
- Link the architecture deepening review from the documentation index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an architecture review covering six opportunities to improve calendar handling, command-line workflows, distribution fitting, output provenance, multi-input alignment, and Palmer calculations.
  - Included implementation considerations, benefits, risks, recommendation strengths, and a prioritized delivery order.
  - Added the review to the documentation index.
  - Added a handoff guide outlining calendar semantics, open design questions, validation steps, and a proposed implementation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->