### PR TITLE
fix: address M1/M2/L1 review followups from #755

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -75,10 +75,15 @@ jobs:
       - name: Run core tests
         run: uv run --no-sync --no-build pytest -m "not benchmark and not validation"
 
+      # Run even when core tests fail: these cover disjoint test sets, and a
+      # core failure would otherwise report them as "skipped" rather than as
+      # the pass/fail they actually are.
       - name: Run validation tests
+        if: ${{ !cancelled() }}
         run: uv run --no-sync --no-build pytest -m validation
 
       - name: Pattern compliance check
+        if: ${{ !cancelled() }}
         run: uv run --no-sync --no-build pytest tests/test_pattern_compliance.py -v
 
   test-minimum-deps:
@@ -103,7 +108,9 @@ jobs:
       - name: Run core tests with minimum dependencies
         run: uv run --no-sync --no-build pytest -m "not benchmark and not validation"
 
+      # See the note on the same step in the `test` job above.
       - name: Run validation tests with minimum dependencies
+        if: ${{ !cancelled() }}
         run: uv run --no-sync --no-build pytest -m validation
 
   notebooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,16 @@ For packaging, release, or workflow changes, also run:
 uv run pytest tests/test_release_integrity.py
 ```
 
+If you edit any document listed in `SUMMARY_FILES` or `FULL_FILES` in
+`scripts/generate_llms_txt.py` — `README.md` and `VALIDATION.md` among them —
+regenerate the derived bundles and commit them alongside the change:
+
+```bash
+uv run scripts/generate_llms_txt.py
+```
+
+Skipping this fails `tests/test_review_scripts.py` in every CI job.
+
 ## Coding conventions
 
 - Follow existing module boundaries and local patterns.
@@ -70,7 +80,9 @@ uv run pytest tests/test_release_integrity.py
 - Use `structlog` for project logging; do not introduce stdlib logging.
 - Keep tests in `tests/` and reference fixtures in `tests/fixture/`.
 - Do not modify unrelated planning artifacts, notebooks, or generated files
-  unless the task explicitly requires it.
+  unless the task explicitly requires it. Editing a source document listed in
+  `scripts/generate_llms_txt.py` does require regenerating `llms.txt` and
+  `llms-full.txt` — see the Validation section above.
 
 ## Release policy
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -72,6 +72,28 @@ completed:
 3. Explicitly defer independent Palmer validation in the release issue and keep
    the current tests labeled as regression coverage only.
 
+## scPDSI Calibration-Anchor Measurement
+
+Wells' self-calibration methodology tunes each climate division's duration
+and K-prime factors so that, by construction, the calibration-period 2nd and
+98th percentiles of the self-calibrated Z-index land at exactly -4.0000 and
++4.0000. Measuring how closely `scpdsi()` reproduces that anchor across all
+344 climate divisions (calibration period 1931-1990) verifies the
+self-calibration percentile-scaling step independently of the NOAA nClimDiv
+comparison above, which instead measures agreement with an external product
+that uses different (fixed, national) K-factors.
+
+| Percentile anchor | Median | Mean | Median deviation | Max deviation | Within +/-0.05 | Within +/-0.25 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2nd (target -4.0000) | -4.0000 | -4.0142 | 0.0102 | 0.9730 | 74% | 93% |
+| 98th (target +4.0000) | +4.0000 | +3.9829 | 0.0130 | 1.5421 | 70% | 91% |
+
+This is regression coverage over the committed fixture set, not independent
+scientific validation: it confirms the self-calibration percentile-scaling
+arithmetic behaves as Wells describes for these 344 divisions, not that the
+resulting scPDSI values themselves match an external authoritative source.
+See "Palmer Authoritative-Reference Decision" above for the latter.
+
 ## References
 
 - Hobbins, M. T., Wood, A., McEvoy, D. J., Huntington, J. L., Morton, C.,

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -76,8 +76,10 @@ completed:
 
 Wells' self-calibration methodology tunes each climate division's duration
 and K-prime factors so that, by construction, the calibration-period 2nd and
-98th percentiles of the self-calibrated Z-index land at exactly -4.0000 and
-+4.0000. Measuring how closely `scpdsi()` reproduces that anchor across all
+98th percentiles of the resulting scPDSI series land at exactly -4.0000 and
++4.0000. (`scpdsi()` takes those percentiles of the PDSI output and rescales
+the Z-index to match; the Z-index is the quantity adjusted, not the quantity
+anchored.) Measuring how closely `scpdsi()` reproduces that anchor across all
 344 climate divisions (calibration period 1931-1990) verifies the
 self-calibration percentile-scaling step independently of the NOAA nClimDiv
 comparison in `tests/test_nclimdiv_reference.py` (see the "Per-Index Evidence"
@@ -88,6 +90,15 @@ uses different (fixed, national) K-factors.
 | --- | --- | --- | --- | --- | --- | --- |
 | 2nd (target -4.0000) | -4.0000 | -4.0142 | 0.0102 | 0.9730 | 74% | 93% |
 | 98th (target +4.0000) | +4.0000 | +3.9829 | 0.0130 | 1.5421 | 70% | 91% |
+
+The medians land on the target exactly while the maxima do not, because
+`scpdsi()` applies a fixed three rescaling passes rather than iterating to a
+fixed point. Divisions whose recursion has not settled within three passes
+retain the residual deviations shown above; this is the reference behaviour,
+not a defect. These figures are regenerated and bounded by
+`test_scpdsi_calibration_anchor_lands_on_target` in
+`tests/test_nclimdiv_reference.py`, so they fail a test rather than rotting
+silently if the rescaling changes.
 
 This is regression coverage over the committed fixture set, not independent
 scientific validation: it confirms the self-calibration percentile-scaling

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -26,7 +26,7 @@ guarded only by internal fixtures.
 | PNP | Validated | Existing fixture tolerances in `tests/test_indices.py` and xarray PNP tests | Percent-of-normal fixture and xarray wrapper tests cover output shape and metadata. | None blocking v2.5. |
 | PCI | Validated | Existing fixture tolerances in `tests/test_indices.py` and xarray PCI tests | Daily rainfall fixture and scalar xarray wrapper tests cover PCI. | None blocking v2.5. |
 | EDDI | Partially validated | NOAA reference tests use `rtol=1e-5`, `atol=1e-5` when fixtures exist | Algorithm property tests always run; NOAA PSL reference tests live in `tests/test_noaa_eddi_reference.py` and are marked `validation`. | `tests/fixture/noaa-eddi-{1,3,6}month/` is not committed. The validation tests skip until independently prepared PET/input and NOAA reference outputs are available. |
-| Palmer PDSI/PHDI/PMDI/Z-Index and scPDSI family | Regression covered, not independently validated | Palmer and scPDSI regression tests use `atol=5e-5`, `rtol=0` | `tests/test_palmer.py` exercises the standard Palmer fixtures; `tests/test_scpdsi.py` compares four self-calibrating outputs and fitted duration factors against Wells-lineage reference fixtures for all 344 climate divisions. Both are marked `validation`. | `tests/fixture/palmer/provenance.json` distinguishes library-generated standard Palmer outputs from Wells-lineage scPDSI outputs. Both fixture sets protect against regressions but are not treated as independent authoritative scientific validation. |
+| Palmer PDSI/PHDI/PMDI/Z-Index and scPDSI family | Regression covered, not independently validated | Palmer and scPDSI regression tests use `atol=5e-5`, `rtol=0`; nClimDiv characterization ceilings documented in `tests/test_nclimdiv_reference.py` | `tests/test_palmer.py` exercises the standard Palmer fixtures; `tests/test_scpdsi.py` compares four self-calibrating outputs and fitted duration factors against Wells-lineage reference fixtures for all 344 climate divisions; `tests/test_nclimdiv_reference.py` characterizes aggregate `pdsi()`/`scpdsi()` agreement against the NOAA NCEI nClimDiv reference arrays. All three are marked `validation`. | `tests/fixture/palmer/provenance.json` distinguishes library-generated standard Palmer outputs from Wells-lineage scPDSI outputs. These fixture sets protect against regressions but are not treated as independent authoritative scientific validation. |
 
 ## EDDI Fixture Policy
 
@@ -80,8 +80,9 @@ and K-prime factors so that, by construction, the calibration-period 2nd and
 +4.0000. Measuring how closely `scpdsi()` reproduces that anchor across all
 344 climate divisions (calibration period 1931-1990) verifies the
 self-calibration percentile-scaling step independently of the NOAA nClimDiv
-comparison above, which instead measures agreement with an external product
-that uses different (fixed, national) K-factors.
+comparison in `tests/test_nclimdiv_reference.py` (see the "Per-Index Evidence"
+table above), which instead measures agreement with an external product that
+uses different (fixed, national) K-factors.
 
 | Percentile anchor | Median | Mean | Median deviation | Max deviation | Within +/-0.05 | Within +/-0.25 |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -288,7 +288,7 @@ guarded only by internal fixtures.
 | PNP | Validated | Existing fixture tolerances in `tests/test_indices.py` and xarray PNP tests | Percent-of-normal fixture and xarray wrapper tests cover output shape and metadata. | None blocking v2.5. |
 | PCI | Validated | Existing fixture tolerances in `tests/test_indices.py` and xarray PCI tests | Daily rainfall fixture and scalar xarray wrapper tests cover PCI. | None blocking v2.5. |
 | EDDI | Partially validated | NOAA reference tests use `rtol=1e-5`, `atol=1e-5` when fixtures exist | Algorithm property tests always run; NOAA PSL reference tests live in `tests/test_noaa_eddi_reference.py` and are marked `validation`. | `tests/fixture/noaa-eddi-{1,3,6}month/` is not committed. The validation tests skip until independently prepared PET/input and NOAA reference outputs are available. |
-| Palmer PDSI/PHDI/PMDI/Z-Index and scPDSI family | Regression covered, not independently validated | Palmer and scPDSI regression tests use `atol=5e-5`, `rtol=0` | `tests/test_palmer.py` exercises the standard Palmer fixtures; `tests/test_scpdsi.py` compares four self-calibrating outputs and fitted duration factors against Wells-lineage reference fixtures for all 344 climate divisions. Both are marked `validation`. | `tests/fixture/palmer/provenance.json` distinguishes library-generated standard Palmer outputs from Wells-lineage scPDSI outputs. Both fixture sets protect against regressions but are not treated as independent authoritative scientific validation. |
+| Palmer PDSI/PHDI/PMDI/Z-Index and scPDSI family | Regression covered, not independently validated | Palmer and scPDSI regression tests use `atol=5e-5`, `rtol=0`; nClimDiv characterization ceilings documented in `tests/test_nclimdiv_reference.py` | `tests/test_palmer.py` exercises the standard Palmer fixtures; `tests/test_scpdsi.py` compares four self-calibrating outputs and fitted duration factors against Wells-lineage reference fixtures for all 344 climate divisions; `tests/test_nclimdiv_reference.py` characterizes aggregate `pdsi()`/`scpdsi()` agreement against the NOAA NCEI nClimDiv reference arrays. All three are marked `validation`. | `tests/fixture/palmer/provenance.json` distinguishes library-generated standard Palmer outputs from Wells-lineage scPDSI outputs. These fixture sets protect against regressions but are not treated as independent authoritative scientific validation. |
 
 ## EDDI Fixture Policy
 
@@ -333,6 +333,29 @@ completed:
    later authoritative implementation note, with provenance and tolerances.
 3. Explicitly defer independent Palmer validation in the release issue and keep
    the current tests labeled as regression coverage only.
+
+## scPDSI Calibration-Anchor Measurement
+
+Wells' self-calibration methodology tunes each climate division's duration
+and K-prime factors so that, by construction, the calibration-period 2nd and
+98th percentiles of the self-calibrated Z-index land at exactly -4.0000 and
++4.0000. Measuring how closely `scpdsi()` reproduces that anchor across all
+344 climate divisions (calibration period 1931-1990) verifies the
+self-calibration percentile-scaling step independently of the NOAA nClimDiv
+comparison in `tests/test_nclimdiv_reference.py` (see the "Per-Index Evidence"
+table above), which instead measures agreement with an external product that
+uses different (fixed, national) K-factors.
+
+| Percentile anchor | Median | Mean | Median deviation | Max deviation | Within +/-0.05 | Within +/-0.25 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2nd (target -4.0000) | -4.0000 | -4.0142 | 0.0102 | 0.9730 | 74% | 93% |
+| 98th (target +4.0000) | +4.0000 | +3.9829 | 0.0130 | 1.5421 | 70% | 91% |
+
+This is regression coverage over the committed fixture set, not independent
+scientific validation: it confirms the self-calibration percentile-scaling
+arithmetic behaves as Wells describes for these 344 divisions, not that the
+resulting scPDSI values themselves match an external authoritative source.
+See "Palmer Authoritative-Reference Decision" above for the latter.
 
 ## References
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -338,8 +338,10 @@ completed:
 
 Wells' self-calibration methodology tunes each climate division's duration
 and K-prime factors so that, by construction, the calibration-period 2nd and
-98th percentiles of the self-calibrated Z-index land at exactly -4.0000 and
-+4.0000. Measuring how closely `scpdsi()` reproduces that anchor across all
+98th percentiles of the resulting scPDSI series land at exactly -4.0000 and
++4.0000. (`scpdsi()` takes those percentiles of the PDSI output and rescales
+the Z-index to match; the Z-index is the quantity adjusted, not the quantity
+anchored.) Measuring how closely `scpdsi()` reproduces that anchor across all
 344 climate divisions (calibration period 1931-1990) verifies the
 self-calibration percentile-scaling step independently of the NOAA nClimDiv
 comparison in `tests/test_nclimdiv_reference.py` (see the "Per-Index Evidence"
@@ -350,6 +352,15 @@ uses different (fixed, national) K-factors.
 | --- | --- | --- | --- | --- | --- | --- |
 | 2nd (target -4.0000) | -4.0000 | -4.0142 | 0.0102 | 0.9730 | 74% | 93% |
 | 98th (target +4.0000) | +4.0000 | +3.9829 | 0.0130 | 1.5421 | 70% | 91% |
+
+The medians land on the target exactly while the maxima do not, because
+`scpdsi()` applies a fixed three rescaling passes rather than iterating to a
+fixed point. Divisions whose recursion has not settled within three passes
+retain the residual deviations shown above; this is the reference behaviour,
+not a defect. These figures are regenerated and bounded by
+`test_scpdsi_calibration_anchor_lands_on_target` in
+`tests/test_nclimdiv_reference.py`, so they fail a test rather than rotting
+silently if the rescaling changes.
 
 This is regression coverage over the committed fixture set, not independent
 scientific validation: it confirms the self-calibration percentile-scaling

--- a/llms.txt
+++ b/llms.txt
@@ -288,7 +288,7 @@ guarded only by internal fixtures.
 | PNP | Validated | Existing fixture tolerances in `tests/test_indices.py` and xarray PNP tests | Percent-of-normal fixture and xarray wrapper tests cover output shape and metadata. | None blocking v2.5. |
 | PCI | Validated | Existing fixture tolerances in `tests/test_indices.py` and xarray PCI tests | Daily rainfall fixture and scalar xarray wrapper tests cover PCI. | None blocking v2.5. |
 | EDDI | Partially validated | NOAA reference tests use `rtol=1e-5`, `atol=1e-5` when fixtures exist | Algorithm property tests always run; NOAA PSL reference tests live in `tests/test_noaa_eddi_reference.py` and are marked `validation`. | `tests/fixture/noaa-eddi-{1,3,6}month/` is not committed. The validation tests skip until independently prepared PET/input and NOAA reference outputs are available. |
-| Palmer PDSI/PHDI/PMDI/Z-Index and scPDSI family | Regression covered, not independently validated | Palmer and scPDSI regression tests use `atol=5e-5`, `rtol=0` | `tests/test_palmer.py` exercises the standard Palmer fixtures; `tests/test_scpdsi.py` compares four self-calibrating outputs and fitted duration factors against Wells-lineage reference fixtures for all 344 climate divisions. Both are marked `validation`. | `tests/fixture/palmer/provenance.json` distinguishes library-generated standard Palmer outputs from Wells-lineage scPDSI outputs. Both fixture sets protect against regressions but are not treated as independent authoritative scientific validation. |
+| Palmer PDSI/PHDI/PMDI/Z-Index and scPDSI family | Regression covered, not independently validated | Palmer and scPDSI regression tests use `atol=5e-5`, `rtol=0`; nClimDiv characterization ceilings documented in `tests/test_nclimdiv_reference.py` | `tests/test_palmer.py` exercises the standard Palmer fixtures; `tests/test_scpdsi.py` compares four self-calibrating outputs and fitted duration factors against Wells-lineage reference fixtures for all 344 climate divisions; `tests/test_nclimdiv_reference.py` characterizes aggregate `pdsi()`/`scpdsi()` agreement against the NOAA NCEI nClimDiv reference arrays. All three are marked `validation`. | `tests/fixture/palmer/provenance.json` distinguishes library-generated standard Palmer outputs from Wells-lineage scPDSI outputs. These fixture sets protect against regressions but are not treated as independent authoritative scientific validation. |
 
 ## EDDI Fixture Policy
 
@@ -333,6 +333,29 @@ completed:
    later authoritative implementation note, with provenance and tolerances.
 3. Explicitly defer independent Palmer validation in the release issue and keep
    the current tests labeled as regression coverage only.
+
+## scPDSI Calibration-Anchor Measurement
+
+Wells' self-calibration methodology tunes each climate division's duration
+and K-prime factors so that, by construction, the calibration-period 2nd and
+98th percentiles of the self-calibrated Z-index land at exactly -4.0000 and
++4.0000. Measuring how closely `scpdsi()` reproduces that anchor across all
+344 climate divisions (calibration period 1931-1990) verifies the
+self-calibration percentile-scaling step independently of the NOAA nClimDiv
+comparison in `tests/test_nclimdiv_reference.py` (see the "Per-Index Evidence"
+table above), which instead measures agreement with an external product that
+uses different (fixed, national) K-factors.
+
+| Percentile anchor | Median | Mean | Median deviation | Max deviation | Within +/-0.05 | Within +/-0.25 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2nd (target -4.0000) | -4.0000 | -4.0142 | 0.0102 | 0.9730 | 74% | 93% |
+| 98th (target +4.0000) | +4.0000 | +3.9829 | 0.0130 | 1.5421 | 70% | 91% |
+
+This is regression coverage over the committed fixture set, not independent
+scientific validation: it confirms the self-calibration percentile-scaling
+arithmetic behaves as Wells describes for these 344 divisions, not that the
+resulting scPDSI values themselves match an external authoritative source.
+See "Palmer Authoritative-Reference Decision" above for the latter.
 
 ## References
 

--- a/llms.txt
+++ b/llms.txt
@@ -338,8 +338,10 @@ completed:
 
 Wells' self-calibration methodology tunes each climate division's duration
 and K-prime factors so that, by construction, the calibration-period 2nd and
-98th percentiles of the self-calibrated Z-index land at exactly -4.0000 and
-+4.0000. Measuring how closely `scpdsi()` reproduces that anchor across all
+98th percentiles of the resulting scPDSI series land at exactly -4.0000 and
++4.0000. (`scpdsi()` takes those percentiles of the PDSI output and rescales
+the Z-index to match; the Z-index is the quantity adjusted, not the quantity
+anchored.) Measuring how closely `scpdsi()` reproduces that anchor across all
 344 climate divisions (calibration period 1931-1990) verifies the
 self-calibration percentile-scaling step independently of the NOAA nClimDiv
 comparison in `tests/test_nclimdiv_reference.py` (see the "Per-Index Evidence"
@@ -350,6 +352,15 @@ uses different (fixed, national) K-factors.
 | --- | --- | --- | --- | --- | --- | --- |
 | 2nd (target -4.0000) | -4.0000 | -4.0142 | 0.0102 | 0.9730 | 74% | 93% |
 | 98th (target +4.0000) | +4.0000 | +3.9829 | 0.0130 | 1.5421 | 70% | 91% |
+
+The medians land on the target exactly while the maxima do not, because
+`scpdsi()` applies a fixed three rescaling passes rather than iterating to a
+fixed point. Divisions whose recursion has not settled within three passes
+retain the residual deviations shown above; this is the reference behaviour,
+not a defect. These figures are regenerated and bounded by
+`test_scpdsi_calibration_anchor_lands_on_target` in
+`tests/test_nclimdiv_reference.py`, so they fail a test rather than rotting
+silently if the rescaling changes.
 
 This is regression coverage over the committed fixture set, not independent
 scientific validation: it confirms the self-calibration percentile-scaling

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -59,7 +59,9 @@ def _render(sources: list[str]) -> str:
 
 def _write(output: str, sources: list[str]) -> None:
     """Write an llms text file from the selected source files."""
-    (ROOT / output).write_text(_render(sources), encoding="utf-8")
+    # newline="\n" keeps the committed bundles LF on every platform; without it
+    # a Windows run would rewrite them with CRLF and churn the diff.
+    (ROOT / output).write_text(_render(sources), encoding="utf-8", newline="\n")
 
 
 def main() -> None:

--- a/src/climate_indices/_palmer_wells.py
+++ b/src/climate_indices/_palmer_wells.py
@@ -127,7 +127,7 @@ def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _F
     for name, value in (("wetc", wetc), ("dryc", dryc), ("dry_spell_c", dry_spell_c)):
         if not np.isfinite(value) or abs(value) >= 1.0:
             raise ConvergenceError(
-                f"invalid fitted duration factors for the Wells recursion: |{name}| = {value!r} is non-finite or >= 1",
+                f"invalid fitted duration factors for the Wells recursion: {name} = {value!r} is non-finite or has magnitude >= 1",
                 algorithm="scPDSI duration-factor calibration",
             )
     return _Factors(

--- a/src/climate_indices/_palmer_wells.py
+++ b/src/climate_indices/_palmer_wells.py
@@ -88,18 +88,25 @@ def _is_exact_zero(value: float) -> bool:
 def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _Factors:
     """Validate fitted duration factors and derive the Wells recurrence coefficients.
 
-    ``dry_coefficient_denominator`` (``drym + wetb``) may be negative, pushing
-    ``|dryc| > 1``. Unlike ``wetc``/``dry_spell_c`` below, ``dryc`` only feeds
-    the x2 recurrence (``min(0.0, ...)`` in ``_candidate_values``), not the
-    unclamped x3 recurrence directly -- but that clamp is one-sided: it caps
-    x2 at zero, it does not bound its magnitude. While an opposite-sign spell
-    is already established (x3 != 0), ``_establish_spell`` returns early
-    without resetting x2, so x2 keeps recurring through ``dryc`` unclamped in
-    magnitude for as long as that spell persists. If ``|dryc| >= 1``, x2 can
-    diverge during that window and then be captured directly into x3 once the
-    established spell abates. The magnitude check below is therefore just as
-    required for ``dryc`` as it is for ``wetc``/``dry_spell_c``, not merely
-    defensive uniformity.
+    All three derived coefficients must be contractions (``|c| < 1``). ``wetc``
+    and ``dry_spell_c`` feed the unclamped x3 recurrence, so that requirement is
+    immediate. ``dryc`` feeds only the x2 recurrence, whose ``min(0.0, ...)``
+    clamp in ``_candidate_values`` is one-sided: it caps x2 at zero but does not
+    bound its magnitude. While an opposite-sign spell is established
+    (``x3 != 0``), ``_establish_spell`` returns early without resetting x2, so
+    across consecutive abatement periods x2 keeps recurring through ``dryc``
+    unbounded in magnitude before being captured into x3 when the spell abates.
+    (The non-abating branches -- ``_continue_spell`` and the
+    ``direction * new_v >= 0`` arm of ``_abatement_transition`` -- do reset x2 to
+    zero, so the exposure is a run of abatement periods, not the whole spell.)
+    ``dryc``'s check is therefore required, not defensive uniformity.
+
+    Taken together with the denominator checks below, the magnitude checks imply
+    ``wetm > 0`` and ``drym > 0`` (since ``wetc == wetb / wet_denominator`` and
+    ``dry_spell_c == dryb / dry_denominator``), which in turn makes
+    ``dry_coefficient_denominator = drym + wetb <= 0`` unreachable: a negative
+    denominator would force ``|dryc| = |wetb / (drym + wetb)| >= 1``. The
+    exact-zero check on it below is thus the only case it can still catch.
     """
     wet_denominator = wetm + wetb
     dry_denominator = drym + dryb
@@ -120,18 +127,14 @@ def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _F
     wetc = 1.0 - wetm / wet_denominator
     # Wells' published implementation intentionally uses the wet intercept in
     # this coefficient, while the dry Z contribution below uses drym + dryb.
-    # dry_coefficient_denominator (drym + wetb) may be negative; see the
-    # function docstring above for why that stays bounded rather than being
-    # rejected outright.
     dryc = 1.0 - drym / dry_coefficient_denominator
     dry_spell_c = 1.0 - drym / dry_denominator
-    # wetc and dry_spell_c drive the unclamped x3 recurrence directly; dryc's
-    # x2 recurrence is only clamped from above (min(0.0, ...)), not bounded in
-    # magnitude, so all three must be contractions -- see the function
-    # docstring above for why dryc's check is required, not just uniformity.
-    # Real-data calibration keeps all three well under 1.0 (max observed
-    # |wetc|=0.983, |dryc|=0.981, |dry_spell_c|=0.982 across 344 nClimDiv
-    # divisions).
+    # All three must be contractions -- see the function docstring above.
+    # Real-data calibration keeps them well under 1.0 (max observed
+    # |wetc|=0.98284, |dryc|=0.98087, |dry_spell_c|=0.98212 across 344 nClimDiv
+    # divisions), i.e. only ~1.7% of margin against this threshold. That margin
+    # is pinned by test_fitted_duration_factor_coefficients_stay_contractions in
+    # tests/test_scpdsi.py, so erosion fails a test rather than surfacing here.
     for name, value in (("wetc", wetc), ("dryc", dryc), ("dry_spell_c", dry_spell_c)):
         if not np.isfinite(value) or abs(value) >= 1.0:
             raise ConvergenceError(
@@ -388,8 +391,11 @@ def calculate(
 
     Raises:
         ConvergenceError: If fitted factors make a recurrence denominator
-            non-finite, non-positive, or zero as applicable, or a Z-index
-            value is infinite.
+            non-finite, non-positive, or zero as applicable; if any derived
+            recurrence coefficient (``wetc``, ``dryc``, ``dry_spell_c``) is
+            non-finite or has magnitude >= 1, which additionally requires both
+            fitted slopes ``wetm`` and ``drym`` to be strictly positive; or if a
+            Z-index value is infinite.
     """
     factors = _validated_factors(wetm, wetb, drym, dryb)
     z = np.asarray(z_values, dtype=float).reshape(-1)

--- a/src/climate_indices/_palmer_wells.py
+++ b/src/climate_indices/_palmer_wells.py
@@ -89,11 +89,17 @@ def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _F
     """Validate fitted duration factors and derive the Wells recurrence coefficients.
 
     ``dry_coefficient_denominator`` (``drym + wetb``) may be negative, pushing
-    ``|dryc| > 1``; that is bounded because ``dryc`` only feeds the clamped x2
-    recurrence (``min(0.0, ...)``) and spell-establishment resets, unlike
-    ``wetc``/``dry_spell_c`` below, which feed the unclamped x3 recurrence and
-    must be contractions. The magnitude check below still rejects ``|dryc| >=
-    1`` defensively, for uniformity with ``wetc``/``dry_spell_c``.
+    ``|dryc| > 1``. Unlike ``wetc``/``dry_spell_c`` below, ``dryc`` only feeds
+    the x2 recurrence (``min(0.0, ...)`` in ``_candidate_values``), not the
+    unclamped x3 recurrence directly -- but that clamp is one-sided: it caps
+    x2 at zero, it does not bound its magnitude. While an opposite-sign spell
+    is already established (x3 != 0), ``_establish_spell`` returns early
+    without resetting x2, so x2 keeps recurring through ``dryc`` unclamped in
+    magnitude for as long as that spell persists. If ``|dryc| >= 1``, x2 can
+    diverge during that window and then be captured directly into x3 once the
+    established spell abates. The magnitude check below is therefore just as
+    required for ``dryc`` as it is for ``wetc``/``dry_spell_c``, not merely
+    defensive uniformity.
     """
     wet_denominator = wetm + wetb
     dry_denominator = drym + dryb
@@ -119,11 +125,13 @@ def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _F
     # rejected outright.
     dryc = 1.0 - drym / dry_coefficient_denominator
     dry_spell_c = 1.0 - drym / dry_denominator
-    # wetc and dry_spell_c drive the unclamped x3 recurrence and must be
-    # contractions; dryc drives the clamped x2 recurrence but is checked too,
-    # for uniformity. Real-data calibration keeps all three well under 1.0
-    # (max observed |wetc|=0.983, |dryc|=0.981, |dry_spell_c|=0.982 across
-    # 344 nClimDiv divisions).
+    # wetc and dry_spell_c drive the unclamped x3 recurrence directly; dryc's
+    # x2 recurrence is only clamped from above (min(0.0, ...)), not bounded in
+    # magnitude, so all three must be contractions -- see the function
+    # docstring above for why dryc's check is required, not just uniformity.
+    # Real-data calibration keeps all three well under 1.0 (max observed
+    # |wetc|=0.983, |dryc|=0.981, |dry_spell_c|=0.982 across 344 nClimDiv
+    # divisions).
     for name, value in (("wetc", wetc), ("dryc", dryc), ("dry_spell_c", dry_spell_c)):
         if not np.isfinite(value) or abs(value) >= 1.0:
             raise ConvergenceError(

--- a/src/climate_indices/_palmer_wells.py
+++ b/src/climate_indices/_palmer_wells.py
@@ -86,6 +86,15 @@ def _is_exact_zero(value: float) -> bool:
 
 
 def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _Factors:
+    """Validate fitted duration factors and derive the Wells recurrence coefficients.
+
+    ``dry_coefficient_denominator`` (``drym + wetb``) may be negative, pushing
+    ``|dryc| > 1``; that is bounded because ``dryc`` only feeds the clamped x2
+    recurrence (``min(0.0, ...)``) and spell-establishment resets, unlike
+    ``wetc``/``dry_spell_c`` below, which feed the unclamped x3 recurrence and
+    must be contractions. The magnitude check below still rejects ``|dryc| >=
+    1`` defensively, for uniformity with ``wetc``/``dry_spell_c``.
+    """
     wet_denominator = wetm + wetb
     dry_denominator = drym + dryb
     dry_coefficient_denominator = drym + wetb
@@ -105,6 +114,9 @@ def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _F
     wetc = 1.0 - wetm / wet_denominator
     # Wells' published implementation intentionally uses the wet intercept in
     # this coefficient, while the dry Z contribution below uses drym + dryb.
+    # dry_coefficient_denominator (drym + wetb) may be negative; see the
+    # function docstring above for why that stays bounded rather than being
+    # rejected outright.
     dryc = 1.0 - drym / dry_coefficient_denominator
     dry_spell_c = 1.0 - drym / dry_denominator
     # wetc and dry_spell_c drive the unclamped x3 recurrence and must be

--- a/src/climate_indices/_palmer_wells.py
+++ b/src/climate_indices/_palmer_wells.py
@@ -107,11 +107,17 @@ def _validated_factors(wetm: float, wetb: float, drym: float, dryb: float) -> _F
     # this coefficient, while the dry Z contribution below uses drym + dryb.
     dryc = 1.0 - drym / dry_coefficient_denominator
     dry_spell_c = 1.0 - drym / dry_denominator
-    if not np.isfinite(wetc) or not np.isfinite(dryc) or not np.isfinite(dry_spell_c):
-        raise ConvergenceError(
-            "invalid fitted duration factors for the Wells recursion",
-            algorithm="scPDSI duration-factor calibration",
-        )
+    # wetc and dry_spell_c drive the unclamped x3 recurrence and must be
+    # contractions; dryc drives the clamped x2 recurrence but is checked too,
+    # for uniformity. Real-data calibration keeps all three well under 1.0
+    # (max observed |wetc|=0.983, |dryc|=0.981, |dry_spell_c|=0.982 across
+    # 344 nClimDiv divisions).
+    for name, value in (("wetc", wetc), ("dryc", dryc), ("dry_spell_c", dry_spell_c)):
+        if not np.isfinite(value) or abs(value) >= 1.0:
+            raise ConvergenceError(
+                f"invalid fitted duration factors for the Wells recursion: |{name}| = {value!r} is non-finite or >= 1",
+                algorithm="scPDSI duration-factor calibration",
+            )
     return _Factors(
         wetm=wetm,
         wetb=wetb,

--- a/src/climate_indices/palmer.py
+++ b/src/climate_indices/palmer.py
@@ -1259,7 +1259,11 @@ def scpdsi(
         InsufficientDataError: If the calibration period cannot supply a
             complete duration-factor fitting window.
         ConvergenceError: If a numerical calibration stage produces unusable
-            factors, percentile anchors, or recurrence denominators.
+            factors, percentile anchors, or recurrence denominators. The
+            duration-factor fit must yield contracting recurrence coefficients;
+            a short or climatologically skewed calibration period can pull a
+            fitted slope non-positive and trigger this (see
+            :func:`climate_indices.self_calibration.duration_factors`).
     """
     return _palmer_calculation(
         "scpdsi",

--- a/tests/test_nclimdiv_reference.py
+++ b/tests/test_nclimdiv_reference.py
@@ -1,0 +1,172 @@
+"""Characterization tests comparing Palmer-family outputs against NOAA nClimDiv.
+
+These tests compare climate_indices' ``pdsi()`` and ``scpdsi()`` outputs
+against the operational NOAA NCEI nClimDiv reference arrays committed under
+``tests/fixture/nclimdiv/`` (see that directory's ``provenance.json``). They
+are loose regression ceilings on aggregated statistics, not tight
+oracle/equality checks -- see VALIDATION.md's "Palmer Authoritative-Reference
+Decision" section for why nClimDiv is treated as an external comparison
+rather than an independently authoritative scientific reference.
+
+Unlike ``test_scpdsi.py::test_climate_division_matches_scpdsi_oracle``, these
+tests deliberately do not compare per-division, per-month values: NOAA's
+national fixed K-factors and climate_indices' per-division self-calibration
+are expected to diverge in the details even when both are implemented
+correctly, so only aggregate statistics across all 344 divisions are
+asserted. If ``pdsi()``/``scpdsi()`` unexpectedly raises for any division,
+the test fails loudly (no broad except/continue) -- the 344-division oracle
+test in ``test_scpdsi.py`` already proves both functions succeed for every
+real division, so a swallowed exception here would hide a real regression.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from climate_indices import palmer
+
+_FIXTURE_ROOT = Path(__file__).parent / "fixture"
+_PALMER_ROOT = _FIXTURE_ROOT / "palmer"
+_NCLIMDIV_ROOT = _FIXTURE_ROOT / "nclimdiv"
+_DIVISION_DIRS = tuple(sorted(path for path in _PALMER_ROOT.iterdir() if path.name.isdigit()))
+_AWCS = json.loads((_FIXTURE_ROOT / "palmer_awc.json").read_text(encoding="utf-8"))
+_DIVISIONS = json.loads((_NCLIMDIV_ROOT / "divisions.json").read_text(encoding="utf-8"))
+_ROW_BY_DIVISION = {division: row for row, division in enumerate(_DIVISIONS)}
+
+_DATA_START_YEAR = 1895
+_CALIBRATION_YEAR_INITIAL = 1931
+_CALIBRATION_YEAR_FINAL = 1990
+
+
+def _division_inputs(division_dir: Path) -> tuple[np.ndarray, np.ndarray, float]:
+    division = division_dir.name
+    return (
+        np.load(division_dir / "precips.npy"),
+        np.load(division_dir / "pet.npy"),
+        _AWCS[division],
+    )
+
+
+def _load_nclimdiv_arrays() -> dict[str, np.ndarray]:
+    return {name: np.load(_NCLIMDIV_ROOT / f"{name}.npy") for name in ("pdsi", "phdi", "pmdi", "zindex")}
+
+
+def _abs_diffs(actual: np.ndarray, reference_row: np.ndarray) -> np.ndarray:
+    """Absolute differences at months where both series report a value."""
+    reference = reference_row.astype(np.float64)
+    finite = ~np.isnan(reference) & ~np.isnan(actual)
+    return np.abs(actual[finite].astype(np.float64) - reference[finite])
+
+
+def _summarize(all_diffs: dict[str, list[np.ndarray]]) -> dict[str, dict[str, float]]:
+    summary = {}
+    for name, diffs in all_diffs.items():
+        stacked = np.concatenate(diffs)
+        summary[name] = {
+            "median": float(np.median(stacked)),
+            "mean": float(np.mean(stacked)),
+            "p90": float(np.percentile(stacked, 90)),
+            "max": float(np.max(stacked)),
+        }
+    return summary
+
+
+@pytest.mark.validation
+def test_pdsi_vs_noaa_nclimdiv_characterization():
+    """Aggregate agreement between plain pdsi() and the NOAA nClimDiv arrays.
+
+    ``pdsi()`` uses the same fixed, nationally uniform duration/K factors as
+    NOAA's operational nClimDiv product, so agreement is expected to be
+    close. Measured across all 344 divisions: pdsi median |Delta| 0.0127
+    (matches tests/fixture/nclimdiv/provenance.json's documented 86.2%
+    within 0.05), mean 0.0432, p90 0.0638, max 7.6336; phdi median 0.0156,
+    max 3.8524; pmdi median 0.0191, max 5.5748; zindex median 0.0129, max
+    1.0176. Ceilings below give ~2x headroom on medians and ~1.5x headroom
+    on maxima.
+    """
+    nclimdiv = _load_nclimdiv_arrays()
+    all_diffs: dict[str, list[np.ndarray]] = {"pdsi": [], "phdi": [], "pmdi": [], "zindex": []}
+
+    for division_dir in _DIVISION_DIRS:
+        division = division_dir.name
+        precips, pet, awc = _division_inputs(division_dir)
+        pdsi_values, phdi_values, pmdi_values, zindex_values, _params = palmer.pdsi(
+            precips, pet, awc, _DATA_START_YEAR, _CALIBRATION_YEAR_INITIAL, _CALIBRATION_YEAR_FINAL
+        )
+        row = _ROW_BY_DIVISION[division]
+        all_diffs["pdsi"].append(_abs_diffs(pdsi_values, nclimdiv["pdsi"][row]))
+        all_diffs["phdi"].append(_abs_diffs(phdi_values, nclimdiv["phdi"][row]))
+        all_diffs["pmdi"].append(_abs_diffs(pmdi_values, nclimdiv["pmdi"][row]))
+        all_diffs["zindex"].append(_abs_diffs(zindex_values, nclimdiv["zindex"][row]))
+
+    summary = _summarize(all_diffs)
+
+    # Measured: pdsi median 0.0127, mean 0.0432, p90 0.0638, max 7.6336.
+    assert summary["pdsi"]["median"] < 0.03, summary["pdsi"]
+    assert summary["pdsi"]["mean"] < 0.1, summary["pdsi"]
+    assert summary["pdsi"]["p90"] < 0.15, summary["pdsi"]
+    assert summary["pdsi"]["max"] < 12.0, summary["pdsi"]
+
+    # Measured: phdi median 0.0156 max 3.8524; pmdi median 0.0191 max 5.5748.
+    assert summary["phdi"]["median"] < 0.04, summary["phdi"]
+    assert summary["phdi"]["max"] < 6.0, summary["phdi"]
+    assert summary["pmdi"]["median"] < 0.05, summary["pmdi"]
+    assert summary["pmdi"]["max"] < 9.0, summary["pmdi"]
+
+    # Measured: zindex median 0.0129, max 1.0176.
+    assert summary["zindex"]["median"] < 0.03, summary["zindex"]
+    assert summary["zindex"]["max"] < 2.0, summary["zindex"]
+
+
+@pytest.mark.validation
+def test_scpdsi_vs_noaa_nclimdiv_characterization():
+    """Aggregate agreement between scpdsi() and the NOAA nClimDiv arrays.
+
+    Unlike plain pdsi(), scpdsi() self-calibrates duration and K-prime
+    factors per climate division (Wells, Goddard, and Hayes 2004), while
+    NOAA's operational nClimDiv product uses fixed national K-factors. The
+    two are expected to diverge substantially by design -- this is expected
+    divergence, not a defect -- so these ceilings are wide, calibrated from
+    aggregate statistics measured across all 344 divisions (GitHub issue
+    #755), with headroom for run-to-run noise rather than a tight
+    per-division tolerance.
+    """
+    nclimdiv = _load_nclimdiv_arrays()
+    all_diffs: dict[str, list[np.ndarray]] = {"pdsi": [], "phdi": [], "pmdi": [], "zindex": []}
+
+    for division_dir in _DIVISION_DIRS:
+        division = division_dir.name
+        precips, pet, awc = _division_inputs(division_dir)
+        scpdsi_values, scphdi_values, scpmdi_values, sczindex_values, params = palmer.scpdsi(
+            precips, pet, awc, _DATA_START_YEAR, _CALIBRATION_YEAR_INITIAL, _CALIBRATION_YEAR_FINAL
+        )
+        assert params is not None, f"{division}: scpdsi() unexpectedly returned no fitted parameters"
+        row = _ROW_BY_DIVISION[division]
+        all_diffs["pdsi"].append(_abs_diffs(scpdsi_values, nclimdiv["pdsi"][row]))
+        all_diffs["phdi"].append(_abs_diffs(scphdi_values, nclimdiv["phdi"][row]))
+        all_diffs["pmdi"].append(_abs_diffs(scpmdi_values, nclimdiv["pmdi"][row]))
+        all_diffs["zindex"].append(_abs_diffs(sczindex_values, nclimdiv["zindex"][row]))
+
+    summary = _summarize(all_diffs)
+
+    # Measured (issue #755, 344 divisions): pdsi median 0.4731, mean 0.7574,
+    # p90 1.7786, max 9.3753. Ceilings below are ~1.5-2x median/mean/p90 and
+    # ~1.5x max.
+    assert summary["pdsi"]["median"] < 0.9, summary["pdsi"]
+    assert summary["pdsi"]["mean"] < 1.5, summary["pdsi"]
+    assert summary["pdsi"]["p90"] < 3.0, summary["pdsi"]
+    assert summary["pdsi"]["max"] < 15.0, summary["pdsi"]
+
+    # Measured: phdi median 0.6055, max 9.0613.
+    assert summary["phdi"]["median"] < 1.1, summary["phdi"]
+    assert summary["phdi"]["max"] < 14.0, summary["phdi"]
+
+    # Measured: pmdi median 0.5714, max 8.9270.
+    assert summary["pmdi"]["median"] < 1.0, summary["pmdi"]
+    assert summary["pmdi"]["max"] < 14.0, summary["pmdi"]
+
+    # Measured: zindex median 0.1525, max 6.9305.
+    assert summary["zindex"]["median"] < 0.3, summary["zindex"]
+    assert summary["zindex"]["max"] < 11.0, summary["zindex"]

--- a/tests/test_nclimdiv_reference.py
+++ b/tests/test_nclimdiv_reference.py
@@ -17,6 +17,14 @@ asserted. If ``pdsi()``/``scpdsi()`` unexpectedly raises for any division,
 the test fails loudly (no broad except/continue) -- the 344-division oracle
 test in ``test_scpdsi.py`` already proves both functions succeed for every
 real division, so a swallowed exception here would hide a real regression.
+
+Ceilings are derived from the measurements in ``_PDSI_MEASURED`` and
+``_SCPDSI_MEASURED`` with the fixed headroom documented in
+``_HEADROOM_BOUNDS`` and enforced by
+``test_ceilings_keep_documented_headroom``. The computation is fully
+deterministic -- committed ``.npy`` inputs and no RNG anywhere in the Palmer
+path -- so the headroom absorbs tolerated library/platform drift and
+refactoring, not stochastic run-to-run noise.
 """
 
 import json
@@ -25,46 +33,94 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from climate_indices import palmer
+from climate_indices import palmer, self_calibration
 
 _FIXTURE_ROOT = Path(__file__).parent / "fixture"
 _PALMER_ROOT = _FIXTURE_ROOT / "palmer"
 _NCLIMDIV_ROOT = _FIXTURE_ROOT / "nclimdiv"
-_DIVISION_DIRS = tuple(sorted(path for path in _PALMER_ROOT.iterdir() if path.name.isdigit()))
-_AWCS = json.loads((_FIXTURE_ROOT / "palmer_awc.json").read_text(encoding="utf-8"))
-_DIVISIONS = json.loads((_NCLIMDIV_ROOT / "divisions.json").read_text(encoding="utf-8"))
-_ROW_BY_DIVISION = {division: row for row, division in enumerate(_DIVISIONS)}
 
 _DATA_START_YEAR = 1895
 _CALIBRATION_YEAR_INITIAL = 1931
 _CALIBRATION_YEAR_FINAL = 1990
 
+_SERIES = ("pdsi", "phdi", "pmdi", "zindex")
 
-def _division_inputs(division_dir: Path) -> tuple[np.ndarray, np.ndarray, float]:
-    division = division_dir.name
-    return (
-        np.load(division_dir / "precips.npy"),
-        np.load(division_dir / "pet.npy"),
-        _AWCS[division],
-    )
+# provenance.json documents 528,384 division-months of overlap. Assert a floor
+# well below that so a regression that turns whole divisions into NaN shrinks
+# the compared sample loudly instead of silently improving the statistics.
+_MIN_COMPARED_MONTHS = 400_000
+
+# Measured across all 344 divisions (calibration period 1931-1990).
+_PDSI_MEASURED = {
+    "pdsi": {"median": 0.0127, "mean": 0.0432, "p90": 0.0638, "max": 7.6336},
+    "phdi": {"median": 0.0156, "max": 3.8524},
+    "pmdi": {"median": 0.0191, "max": 5.5748},
+    "zindex": {"median": 0.0129, "max": 1.0176},
+}
+_PDSI_CEILINGS = {
+    "pdsi": {"median": 0.03, "mean": 0.1, "p90": 0.15, "max": 12.0},
+    "phdi": {"median": 0.04, "max": 6.0},
+    "pmdi": {"median": 0.05, "max": 9.0},
+    "zindex": {"median": 0.03, "max": 1.6},
+}
+
+# Measured across all 344 divisions (GitHub issue #755).
+_SCPDSI_MEASURED = {
+    "pdsi": {"median": 0.4731, "mean": 0.7574, "p90": 1.7786, "max": 9.3753},
+    "phdi": {"median": 0.6055, "max": 9.0613},
+    "pmdi": {"median": 0.5714, "max": 8.9270},
+    "zindex": {"median": 0.1525, "max": 6.9305},
+}
+_SCPDSI_CEILINGS = {
+    "pdsi": {"median": 0.9, "mean": 1.5, "p90": 3.0, "max": 15.0},
+    "phdi": {"median": 1.1, "max": 14.0},
+    "pmdi": {"median": 1.0, "max": 14.0},
+    "zindex": {"median": 0.3, "max": 11.0},
+}
+
+# (minimum, maximum) permitted ceiling-to-measurement ratio, by statistic.
+_HEADROOM_BOUNDS = {"max": (1.5, 1.7), "other": (1.65, 2.7)}
 
 
-def _load_nclimdiv_arrays() -> dict[str, np.ndarray]:
-    return {name: np.load(_NCLIMDIV_ROOT / f"{name}.npy") for name in ("pdsi", "phdi", "pmdi", "zindex")}
+@pytest.fixture(scope="module")
+def division_dirs() -> tuple[Path, ...]:
+    return tuple(sorted(path for path in _PALMER_ROOT.iterdir() if path.name.isdigit()))
+
+
+@pytest.fixture(scope="module")
+def awcs(palmer_awcs) -> dict:
+    return palmer_awcs
+
+
+@pytest.fixture(scope="module")
+def row_by_division() -> dict[str, int]:
+    divisions = json.loads((_NCLIMDIV_ROOT / "divisions.json").read_text(encoding="utf-8"))
+    return {division: row for row, division in enumerate(divisions)}
+
+
+@pytest.fixture(scope="module")
+def nclimdiv() -> dict[str, np.ndarray]:
+    return {name: np.load(_NCLIMDIV_ROOT / f"{name}.npy") for name in _SERIES}
 
 
 def _abs_diffs(actual: np.ndarray, reference_row: np.ndarray) -> np.ndarray:
     """Absolute differences at months where both series report a value."""
     reference = reference_row.astype(np.float64)
-    finite = ~np.isnan(reference) & ~np.isnan(actual)
-    return np.abs(actual[finite].astype(np.float64) - reference[finite])
+    both_present = ~np.isnan(reference) & ~np.isnan(actual)
+    return np.abs(actual[both_present].astype(np.float64) - reference[both_present])
 
 
 def _summarize(all_diffs: dict[str, list[np.ndarray]]) -> dict[str, dict[str, float]]:
+    """Aggregate per-division absolute differences into comparable statistics."""
     summary = {}
     for name, diffs in all_diffs.items():
         stacked = np.concatenate(diffs)
+        assert stacked.size >= _MIN_COMPARED_MONTHS, (
+            f"{name}: only {stacked.size} division-months compared, expected at least "
+            f"{_MIN_COMPARED_MONTHS} -- the reference and computed series barely overlap"
+        )
         summary[name] = {
+            "count": int(stacked.size),
             "median": float(np.median(stacked)),
             "mean": float(np.mean(stacked)),
             "p90": float(np.percentile(stacked, 90)),
@@ -73,100 +129,114 @@ def _summarize(all_diffs: dict[str, list[np.ndarray]]) -> dict[str, dict[str, fl
     return summary
 
 
+def _collect_diffs(function, division_dirs, awcs, row_by_division, nclimdiv) -> dict[str, dict[str, float]]:
+    all_diffs: dict[str, list[np.ndarray]] = {name: [] for name in _SERIES}
+    for division_dir in division_dirs:
+        division = division_dir.name
+        values = function(
+            np.load(division_dir / "precips.npy"),
+            np.load(division_dir / "pet.npy"),
+            awcs[division],
+            _DATA_START_YEAR,
+            _CALIBRATION_YEAR_INITIAL,
+            _CALIBRATION_YEAR_FINAL,
+        )
+        assert values[4] is not None, f"{division}: {function.__name__}() returned no fitted parameters"
+        row = row_by_division[division]
+        for offset, name in enumerate(_SERIES):
+            all_diffs[name].append(_abs_diffs(values[offset], nclimdiv[name][row]))
+    return _summarize(all_diffs)
+
+
+def test_division_directories_match_nclimdiv_index(division_dirs, row_by_division):
+    """Every fixture division must have a reference row, and vice versa."""
+    assert {path.name for path in division_dirs} == set(row_by_division)
+
+
+def test_ceilings_keep_documented_headroom():
+    """Ceilings must stay within the headroom the module docstring advertises.
+
+    Without this, a ceiling can be widened to accommodate a regression while the
+    stated rationale silently stops describing the assertions.
+    """
+    for label, ceilings, measured in (
+        ("pdsi", _PDSI_CEILINGS, _PDSI_MEASURED),
+        ("scpdsi", _SCPDSI_CEILINGS, _SCPDSI_MEASURED),
+    ):
+        for series, stats in ceilings.items():
+            for stat, ceiling in stats.items():
+                low, high = _HEADROOM_BOUNDS["max" if stat == "max" else "other"]
+                ratio = ceiling / measured[series][stat]
+                assert low <= ratio <= high, (
+                    f"{label} {series} {stat}: ceiling is {ratio:.2f}x measured, want {low}-{high}x"
+                )
+
+
 @pytest.mark.validation
-def test_pdsi_vs_noaa_nclimdiv_characterization():
-    """Aggregate agreement between plain pdsi() and the NOAA nClimDiv arrays.
+@pytest.mark.parametrize(
+    ("function", "ceilings"),
+    [(palmer.pdsi, _PDSI_CEILINGS), (palmer.scpdsi, _SCPDSI_CEILINGS)],
+    ids=["pdsi", "scpdsi"],
+)
+def test_palmer_vs_noaa_nclimdiv_characterization(function, ceilings, division_dirs, awcs, row_by_division, nclimdiv):
+    """Aggregate agreement between a Palmer entry point and the NOAA nClimDiv arrays.
 
     ``pdsi()`` uses the same fixed, nationally uniform duration/K factors as
-    NOAA's operational nClimDiv product, so agreement is expected to be
-    close. Measured across all 344 divisions: pdsi median |Delta| 0.0127
-    (matches tests/fixture/nclimdiv/provenance.json's documented 86.2%
-    within 0.05), mean 0.0432, p90 0.0638, max 7.6336; phdi median 0.0156,
-    max 3.8524; pmdi median 0.0191, max 5.5748; zindex median 0.0129, max
-    1.0176. Ceilings below give ~2x headroom on medians and ~1.5x headroom
-    on maxima.
+    NOAA's operational nClimDiv product, so agreement is close; its measured
+    median |Delta| of 0.0127 is consistent with
+    ``tests/fixture/nclimdiv/provenance.json``, which records that same median
+    alongside 86.2% of months within 0.05 (a fraction this test does not
+    recompute). ``scpdsi()`` self-calibrates duration and K-prime factors per
+    division (Wells, Goddard, and Hayes 2004) while NOAA uses fixed national
+    K-factors, so the two diverge substantially by design -- expected
+    divergence, not a defect -- and its ceilings are correspondingly wider.
     """
-    nclimdiv = _load_nclimdiv_arrays()
-    all_diffs: dict[str, list[np.ndarray]] = {"pdsi": [], "phdi": [], "pmdi": [], "zindex": []}
-
-    for division_dir in _DIVISION_DIRS:
-        division = division_dir.name
-        precips, pet, awc = _division_inputs(division_dir)
-        pdsi_values, phdi_values, pmdi_values, zindex_values, _params = palmer.pdsi(
-            precips, pet, awc, _DATA_START_YEAR, _CALIBRATION_YEAR_INITIAL, _CALIBRATION_YEAR_FINAL
-        )
-        row = _ROW_BY_DIVISION[division]
-        all_diffs["pdsi"].append(_abs_diffs(pdsi_values, nclimdiv["pdsi"][row]))
-        all_diffs["phdi"].append(_abs_diffs(phdi_values, nclimdiv["phdi"][row]))
-        all_diffs["pmdi"].append(_abs_diffs(pmdi_values, nclimdiv["pmdi"][row]))
-        all_diffs["zindex"].append(_abs_diffs(zindex_values, nclimdiv["zindex"][row]))
-
-    summary = _summarize(all_diffs)
-
-    # Measured: pdsi median 0.0127, mean 0.0432, p90 0.0638, max 7.6336.
-    assert summary["pdsi"]["median"] < 0.03, summary["pdsi"]
-    assert summary["pdsi"]["mean"] < 0.1, summary["pdsi"]
-    assert summary["pdsi"]["p90"] < 0.15, summary["pdsi"]
-    assert summary["pdsi"]["max"] < 12.0, summary["pdsi"]
-
-    # Measured: phdi median 0.0156 max 3.8524; pmdi median 0.0191 max 5.5748.
-    assert summary["phdi"]["median"] < 0.04, summary["phdi"]
-    assert summary["phdi"]["max"] < 6.0, summary["phdi"]
-    assert summary["pmdi"]["median"] < 0.05, summary["pmdi"]
-    assert summary["pmdi"]["max"] < 9.0, summary["pmdi"]
-
-    # Measured: zindex median 0.0129, max 1.0176.
-    assert summary["zindex"]["median"] < 0.03, summary["zindex"]
-    assert summary["zindex"]["max"] < 2.0, summary["zindex"]
+    summary = _collect_diffs(function, division_dirs, awcs, row_by_division, nclimdiv)
+    for series, stats in ceilings.items():
+        for stat, ceiling in stats.items():
+            assert summary[series][stat] < ceiling, f"{series} {stat}: {summary[series]}"
 
 
 @pytest.mark.validation
-def test_scpdsi_vs_noaa_nclimdiv_characterization():
-    """Aggregate agreement between scpdsi() and the NOAA nClimDiv arrays.
+def test_scpdsi_calibration_anchor_lands_on_target(division_dirs, awcs):
+    """Calibration-period 2nd/98th percentiles of scPDSI should land on -/+4.
 
-    Unlike plain pdsi(), scpdsi() self-calibrates duration and K-prime
-    factors per climate division (Wells, Goddard, and Hayes 2004), while
-    NOAA's operational nClimDiv product uses fixed national K-factors. The
-    two are expected to diverge substantially by design -- this is expected
-    divergence, not a defect -- so these ceilings are wide, calibrated from
-    aggregate statistics measured across all 344 divisions (GitHub issue
-    #755), with headroom for run-to-run noise rather than a tight
-    per-division tolerance.
+    This is the defining property of Wells self-calibration, and the source of
+    the figures published in VALIDATION.md's "scPDSI Calibration-Anchor
+    Measurement" section. ``scpdsi()`` applies a fixed three rescaling passes
+    rather than iterating to a fixed point, so unsettled divisions retain a
+    residual deviation; the ceilings bound that residual.
     """
-    nclimdiv = _load_nclimdiv_arrays()
-    all_diffs: dict[str, list[np.ndarray]] = {"pdsi": [], "phdi": [], "pmdi": [], "zindex": []}
+    start = (_CALIBRATION_YEAR_INITIAL - _DATA_START_YEAR) * 12
+    end = (_CALIBRATION_YEAR_FINAL - _DATA_START_YEAR + 1) * 12
 
-    for division_dir in _DIVISION_DIRS:
+    low_deviations = []
+    high_deviations = []
+    for division_dir in division_dirs:
         division = division_dir.name
-        precips, pet, awc = _division_inputs(division_dir)
-        scpdsi_values, scphdi_values, scpmdi_values, sczindex_values, params = palmer.scpdsi(
-            precips, pet, awc, _DATA_START_YEAR, _CALIBRATION_YEAR_INITIAL, _CALIBRATION_YEAR_FINAL
-        )
-        assert params is not None, f"{division}: scpdsi() unexpectedly returned no fitted parameters"
-        row = _ROW_BY_DIVISION[division]
-        all_diffs["pdsi"].append(_abs_diffs(scpdsi_values, nclimdiv["pdsi"][row]))
-        all_diffs["phdi"].append(_abs_diffs(scphdi_values, nclimdiv["phdi"][row]))
-        all_diffs["pmdi"].append(_abs_diffs(scpmdi_values, nclimdiv["pmdi"][row]))
-        all_diffs["zindex"].append(_abs_diffs(sczindex_values, nclimdiv["zindex"][row]))
+        scpdsi_values = palmer.scpdsi(
+            np.load(division_dir / "precips.npy"),
+            np.load(division_dir / "pet.npy"),
+            awcs[division],
+            _DATA_START_YEAR,
+            _CALIBRATION_YEAR_INITIAL,
+            _CALIBRATION_YEAR_FINAL,
+        )[0]
+        window = scpdsi_values[start:end]
+        low_deviations.append(abs(self_calibration.nan_safe_percentile(window, 0.02) - (-4.0)))
+        high_deviations.append(abs(self_calibration.nan_safe_percentile(window, 0.98) - 4.0))
 
-    summary = _summarize(all_diffs)
+    low = np.asarray(low_deviations)
+    high = np.asarray(high_deviations)
+    assert low.size == high.size == len(division_dirs)
 
-    # Measured (issue #755, 344 divisions): pdsi median 0.4731, mean 0.7574,
-    # p90 1.7786, max 9.3753. Ceilings below are ~1.5-2x median/mean/p90 and
-    # ~1.5x max.
-    assert summary["pdsi"]["median"] < 0.9, summary["pdsi"]
-    assert summary["pdsi"]["mean"] < 1.5, summary["pdsi"]
-    assert summary["pdsi"]["p90"] < 3.0, summary["pdsi"]
-    assert summary["pdsi"]["max"] < 15.0, summary["pdsi"]
-
-    # Measured: phdi median 0.6055, max 9.0613.
-    assert summary["phdi"]["median"] < 1.1, summary["phdi"]
-    assert summary["phdi"]["max"] < 14.0, summary["phdi"]
-
-    # Measured: pmdi median 0.5714, max 8.9270.
-    assert summary["pmdi"]["median"] < 1.0, summary["pmdi"]
-    assert summary["pmdi"]["max"] < 14.0, summary["pmdi"]
-
-    # Measured: zindex median 0.1525, max 6.9305.
-    assert summary["zindex"]["median"] < 0.3, summary["zindex"]
-    assert summary["zindex"]["max"] < 11.0, summary["zindex"]
+    # Measured: 2nd median deviation 0.0102, max 0.9730, 74% within 0.05, 93%
+    # within 0.25; 98th median deviation 0.0130, max 1.5421, 70% and 91%.
+    for label, deviations, median_ceiling, max_ceiling, within_005, within_025 in (
+        ("2nd", low, 0.03, 2.0, 0.60, 0.85),
+        ("98th", high, 0.03, 2.5, 0.55, 0.80),
+    ):
+        assert float(np.median(deviations)) < median_ceiling, f"{label}: median deviation {np.median(deviations)}"
+        assert float(np.max(deviations)) < max_ceiling, f"{label}: max deviation {np.max(deviations)}"
+        assert float(np.mean(deviations <= 0.05)) > within_005, f"{label}: within 0.05 fraction too low"
+        assert float(np.mean(deviations <= 0.25)) > within_025, f"{label}: within 0.25 fraction too low"

--- a/tests/test_palmer_wells.py
+++ b/tests/test_palmer_wells.py
@@ -1,5 +1,7 @@
 """Unit tests for the Wells-lineage Palmer recursion used by scPDSI."""
 
+from dataclasses import replace
+
 import numpy as np
 import pytest
 
@@ -125,11 +127,51 @@ def test_zero_abatement_denominator_raises_convergence_error():
 @pytest.mark.parametrize(
     ("wetm", "wetb", "drym", "dryb", "coefficient"),
     [
+        # Each tuple must trip its named coefficient and no other, so the match
+        # pattern below is anchored to the message's "<name> = " fragment rather
+        # than searching for the bare name. Computed values, for maintenance:
+        #   wetc case:        wetc=1.000000  dryc=0.500000  dry_spell_c=0.500000
+        #   dryc case:        wetc=-0.250000 dryc=2.000000  dry_spell_c=0.500000
+        #   dry_spell_c case: wetc=-0.111111 dryc=0.990099  dry_spell_c=1.500000
+        # Note the dry_spell_c case leaves dryc only ~1% below the threshold --
+        # perturb those factors and it can start tripping dryc instead.
         (0.0, 1.0, 1.0, 1.0, "wetc"),
         (10.0, -2.0, 1.0, 1.0, "dryc"),
         (1000.0, -100.0, -1.0, 3.0, "dry_spell_c"),
     ],
+    ids=["wetc", "dryc", "dry_spell_c"],
 )
 def test_duration_factor_magnitude_at_or_above_one_raises_convergence_error(wetm, wetb, drym, dryb, coefficient):
-    with pytest.raises(ConvergenceError, match=coefficient):
+    with pytest.raises(ConvergenceError, match=rf"recursion: {coefficient} = "):
         _run([0.0], wetm=wetm, wetb=wetb, drym=drym, dryb=dryb)
+
+
+def test_dry_candidate_clamp_does_not_bound_magnitude():
+    """The x2 clamp is one-sided, which is why ``dryc`` needs a magnitude check.
+
+    ``_candidate_values`` applies ``min(0.0, ...)`` to x2. That caps it at zero
+    but leaves negative values free to grow, so a non-contracting ``dryc`` makes
+    x2 diverge. This pins the mechanism the ``_validated_factors`` docstring
+    cites as the justification for rejecting ``|dryc| >= 1``.
+    """
+    factors = _palmer_wells._Factors(
+        wetm=1.0,
+        wetb=1.0,
+        drym=1.0,
+        dryb=1.0,
+        wet_denominator=2.0,
+        dry_denominator=2.0,
+        wetc=0.5,
+        # The value the (10.0, -2.0, 1.0, 1.0) factors above produce.
+        dryc=2.0,
+        dry_spell_c=0.5,
+    )
+    state = _palmer_wells._State(x1=0.0, x2=-1.0, x3=0.0, v=0.0, probability=0.0)
+    magnitudes = []
+    for _ in range(5):
+        _, x2 = _palmer_wells._candidate_values(state, 0.0, factors)
+        magnitudes.append(abs(x2))
+        state = replace(state, x2=x2)
+
+    assert magnitudes == sorted(magnitudes)
+    assert magnitudes[-1] > magnitudes[0]

--- a/tests/test_palmer_wells.py
+++ b/tests/test_palmer_wells.py
@@ -120,3 +120,16 @@ def test_invalid_duration_factor_denominators_raise_convergence_error(wetm, wetb
 def test_zero_abatement_denominator_raises_convergence_error():
     with pytest.raises(ConvergenceError, match="abatement probability"):
         _run([2.0, 0.0])
+
+
+@pytest.mark.parametrize(
+    ("wetm", "wetb", "drym", "dryb", "coefficient"),
+    [
+        (0.0, 1.0, 1.0, 1.0, "wetc"),
+        (10.0, -2.0, 1.0, 1.0, "dryc"),
+        (1000.0, -100.0, -1.0, 3.0, "dry_spell_c"),
+    ],
+)
+def test_duration_factor_magnitude_at_or_above_one_raises_convergence_error(wetm, wetb, drym, dryb, coefficient):
+    with pytest.raises(ConvergenceError, match=coefficient):
+        _run([0.0], wetm=wetm, wetb=wetb, drym=drym, dryb=dryb)

--- a/tests/test_review_scripts.py
+++ b/tests/test_review_scripts.py
@@ -83,7 +83,9 @@ def test_read_missing_llms_source_names_file_and_source_lists() -> None:
 )
 def test_llms_bundle_matches_configured_sources(output: Path, sources: list[str]) -> None:
     """Committed llms bundles should exactly match their configured sources."""
-    assert (ROOT / output).read_text(encoding="utf-8") == generate_llms_txt._render(sources)
+    assert (ROOT / output).read_text(encoding="utf-8") == generate_llms_txt._render(sources), (
+        f"{output} is stale relative to {sources}. Regenerate with: uv run scripts/generate_llms_txt.py"
+    )
 
 
 def test_render_builds_header_and_ordered_sections(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_scpdsi.py
+++ b/tests/test_scpdsi.py
@@ -232,3 +232,30 @@ def test_climate_division_matches_scpdsi_oracle(division_dir):
         rtol=RTOL,
         err_msg=f"{division}: duration factors mismatch",
     )
+
+
+@pytest.mark.validation
+def test_fitted_duration_factor_coefficients_stay_contractions():
+    """Real-data duration factors must keep the Wells coefficients contracting.
+
+    ``_palmer_wells._validated_factors`` rejects any coefficient with magnitude
+    >= 1. Across these 344 divisions the coefficients peak at ~0.983, i.e. only
+    ~1.7% of margin. This pins that margin: erosion fails here, with the worst
+    division named, rather than surfacing later as a ConvergenceError on user
+    data. ``test_climate_division_matches_scpdsi_oracle`` ties the library's
+    fitted factors to the same ``scdurfact.npy`` values read here.
+    """
+    worst = {"wetc": (0.0, ""), "dryc": (0.0, ""), "dry_spell_c": (0.0, "")}
+    for division_dir in _DIVISION_DIRS:
+        wetm, wetb, drym, dryb = (float(value) for value in np.load(division_dir / "scdurfact.npy"))
+        coefficients = {
+            "wetc": 1.0 - wetm / (wetm + wetb),
+            "dryc": 1.0 - drym / (drym + wetb),
+            "dry_spell_c": 1.0 - drym / (drym + dryb),
+        }
+        for name, value in coefficients.items():
+            if abs(value) > worst[name][0]:
+                worst[name] = (abs(value), division_dir.name)
+
+    for name, (magnitude, division) in worst.items():
+        assert magnitude < 0.99, f"{name} margin eroded to {magnitude:.5f} at division {division}"


### PR DESCRIPTION
## Summary

Addresses the MEDIUM and LOW findings and recommendation 3 from #755, the post-merge scientific review of the scPDSI implementation (PR #748).

| Commit | Finding | Type |
| --- | --- | --- |
| `fix: bound coefficient magnitude in Wells duration-factor validation` | **M1** | Guard against `|wetc|`, `|dryc|`, `|dry_spell_c| >= 1`, which previously fed the unclamped x3 recurrence undetected and produced unbounded geometric divergence with no exception raised. |
| `docs: document mixed-denominator bound in _validated_factors` | **M2** | Documentation only. Explains why the mixed denominator `drym + wetb` can validly go negative — `dryc` only feeds the clamped x2 recurrence, unlike `wetc`/`dry_spell_c`. No formula change. |
| `test: wire up nClimDiv ground truth as characterization tests` | **L1** | New `tests/test_nclimdiv_reference.py`, two `@pytest.mark.validation` tests characterizing `pdsi()`/`scpdsi()` aggregate agreement with the previously-unreferenced NOAA nClimDiv fixtures. |
| `docs: record scPDSI calibration-anchor measurement in VALIDATION.md` | Recommendation 3 | Documents the measured ∓4 self-calibration percentile anchor across all 344 divisions. |

**L2 was intentionally skipped** — the issue explicitly states "no action required" for it (an unverifiable claim about an out-of-tree GPLv3 harness implementation detail, consistent with existing provenance docs). `docs/superpowers/specs/2026-08-08-scpdsi-pr3-oracle-harness-design.md` was not touched.

## M1 verification (real-data safety)

Max coefficient magnitudes measured across all 344 climate divisions: `|wetc|` 0.983, `|dryc|` 0.981, `|dry_spell_c|` 0.982 — all comfortably under the new `>= 1.0` threshold. The 344-division scPDSI oracle test (`test_climate_division_matches_scpdsi_oracle`, `atol=5e-5`) was run before and after the M1 change and is unaffected:

- **Before**: `348 passed, 9 skipped, 1201 deselected`
- **After**: `350 passed, 9 skipped, 1204 deselected` (the +2 passed are the new L1 validation tests; the +3 deselected are the new M1 unit-test cases, which aren't marked `validation`)

## Test plan

- [x] `uv run ruff check src/ tests/` — no findings
- [x] `uv run ruff format --check src/ tests/` — no changes needed
- [x] `uv run mypy src/` — no issues
- [x] `uv run pytest -m "not benchmark and not validation"` — 1180 passed, 0 failed
- [x] `uv run pytest -m validation` — 350 passed, 9 skipped (see before/after above), including the 344-division scPDSI oracle unchanged at `atol=5e-5`
- [x] Branch coverage on `src/climate_indices/_palmer_wells.py`: **100%** (baseline was 99%; the new coefficient-magnitude guard's 3 branches are each covered by an isolated parametrized test case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden Wells scPDSI recurrence validation and expand scientific regression coverage and documentation.

New Features:
- Add validation characterization tests comparing Palmer and scPDSI outputs with NOAA nClimDiv aggregates and checking scPDSI calibration anchors across 344 climate divisions.

Bug Fixes:
- Reject Wells duration-factor fits whose recurrence coefficients are non-finite or have magnitude at least one, preventing unbounded recurrence behavior.

Enhancements:
- Document the scPDSI calibration-anchor measurements and clarify the mixed-denominator behavior and recurrence safety requirements.
- Improve CI so validation and pattern-compliance tests run independently after core-test failures.
- Improve generated LLM bundle portability and provide clearer stale-bundle guidance.

CI:
- Ensure validation and pattern-compliance test jobs continue reporting results unless the workflow is cancelled.

Documentation:
- Expand validation documentation with nClimDiv characterization coverage and measured scPDSI calibration-anchor results.
- Document regeneration requirements for derived LLM bundles.

Tests:
- Add targeted coverage for non-contracting Wells recurrence coefficients and one-sided dry-candidate growth.
- Add real-data contraction-margin checks and NOAA nClimDiv characterization tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added regression coverage comparing PDSI and self-calibrated PDSI results with NOAA climate-division reference data.
  - Added validation across all 344 climate divisions, including calibration-anchor accuracy and coefficient stability checks.
  - Added coverage confirming convergence errors for unstable wet- and dry-spell coefficient values.
  - Improved validation reporting and ensured additional checks run even when core tests fail.

- **Documentation**
  - Clarified self-calibrated PDSI calibration-anchor targets and residual deviations.
  - Expanded explanations of stability checks and convergence requirements for drought-index calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->