### PR TITLE
fix: correct typos in docstrings, comments, and CLI text

### DIFF
--- a/src/climate_indices/__main__.py
+++ b/src/climate_indices/__main__.py
@@ -35,7 +35,7 @@ _logger = utils.get_logger(__name__, logging.INFO)
 
 class InputType(Enum):
     """
-    Enumeration type for differentiating between gridded, timeseriesn and US
+    Enumeration type for differentiating between gridded, timeseries, and US
     climate division datasets.
     """
 
@@ -150,7 +150,7 @@ def _validate_args(args: argparse.Namespace) -> InputType:
         # don't allow a daily periodicity (yet, this will be
         # possible once we have Hargreaves or a daily Thornthwaite)
         if args.periodicity is not compute.Periodicity.monthly:
-            msg = "Invalid periodicity argument for PET: " + f"'{args.periodicity}' -- only 'monthly'' is supported"
+            msg = "Invalid periodicity argument for PET: " + f"'{args.periodicity}' -- only 'monthly' is supported"
             _logger.error(msg)
             raise ValueError(msg)
 
@@ -1588,7 +1588,7 @@ def main() -> None:
         )
         parser.add_argument(
             "--multiprocessing",
-            help="Indices to compute",
+            help="options for multiprocessing -- single core, all cores but one, or all cores",
             choices=["single", "all_but_one", "all"],
             required=False,
             default="all_but_one",

--- a/src/climate_indices/compute.py
+++ b/src/climate_indices/compute.py
@@ -292,7 +292,7 @@ def _probability_of_zero(
 
     else:
         # determine the number of time steps per year
-        # (we expect 12 for monthly, 366 for daiy)
+        # (we expect 12 for monthly, 366 for daily)
         time_steps_per_year = values.shape[1]
         if time_steps_per_year not in (12, 366):
             _log_and_raise_shape_error(shape=values.shape)

--- a/src/climate_indices/indices.py
+++ b/src/climate_indices/indices.py
@@ -1014,7 +1014,7 @@ def pci(
 
     :param rainfall_mm: an array of daily rainfall value in a year,
         in mm
-    :return: PCI value for the year in aa numpy array
+    :return: PCI value for the year in a numpy array
     :rtype: 1-D numpy.ndarray of float
     """
     # bind context and emit calculation_started event

--- a/src/climate_indices/utils.py
+++ b/src/climate_indices/utils.py
@@ -160,7 +160,7 @@ def is_data_valid(
     Returns if an array is valid or not, i.e. a supported array type
     (ndarray or MaskArray) which is not all-NaN.
 
-    :param data: data object, expected as either numpy.ndarry or numpy.ma.MaskArray
+    :param data: data object, expected as either numpy.ndarray or numpy.ma.MaskArray
     :return: True if array is non-NaN for at least one element
         and is an array type valid for processing by other modules
     :rtype: boolean
@@ -415,7 +415,7 @@ def transform_to_366day(
             # from the original into the all_leap array
             original_year_end_index = original_index + 365
             if len(original) < original_year_end_index:
-                # this should be the final year, and we're just adding the remained days
+                # this should be the final year, and we're just adding the remaining days
                 remainder = original[original_index + 59 :]
                 difference = len(all_leap[all_leap_index + 60 :]) - len(remainder)
                 if difference > 0:


### PR DESCRIPTION
A few text-only corrections I noticed while reading through the package:

- `compute.py`: "366 for daiy" -> "daily"
- `indices.py`: "PCI value for the year in aa numpy array" -> "a numpy array"
- `utils.py`: "numpy.ndarry" -> "numpy.ndarray", "adding the remained days" -> "remaining days"
- `__main__.py`: "gridded, timeseriesn and US" -> "timeseries," in the `InputType` docstring, and a doubled quote in the PET periodicity error message (`only 'monthly'' is supported`)
- `__main__.py`: the `--multiprocessing` help text read "Indices to compute", which is `--index`'s help copied by mistake; it now describes the three choices it actually accepts

No functional changes; `--index`'s own help text is untouched, and none of
the edited strings are asserted on in the tests.

## Summary by Sourcery

Correct user-facing and developer-facing text throughout the package without changing functionality.

Enhancements:
- Correct typos and improve wording in docstrings, comments, and the PET validation error message.
- Clarify the --multiprocessing CLI help text to describe its supported options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected typos in command-line help text, error messages, comments, and API documentation.
  - Clarified the available multiprocessing options in the command-line interface.
  - Improved descriptions of time series data, valid arrays, and remaining days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->