### PR TITLE
refactor: simplify optional psutil import

### DIFF
--- a/src/climate_indices/performance.py
+++ b/src/climate_indices/performance.py
@@ -40,33 +40,19 @@ if TYPE_CHECKING:
 # 1 GB threshold for triggering memory metrics logging
 LARGE_ARRAY_THRESHOLD_BYTES = 1_073_741_824
 
-# cached psutil availability flag (set on first call to get_process_memory_mb)
-_PSUTIL_AVAILABLE: bool | None = None
-
 
 def get_process_memory_mb() -> float | None:
     """Get current process memory usage in megabytes.
 
-    Uses psutil if available. On first call, attempts to import psutil and caches
-    the result for subsequent calls.
+    Uses psutil if available.
 
     Returns:
         Current RSS (Resident Set Size) memory in MB, or None if psutil is not installed.
     """
-    global _PSUTIL_AVAILABLE
-
-    if _PSUTIL_AVAILABLE is None:
-        try:
-            import psutil  # noqa: F401
-
-            _PSUTIL_AVAILABLE = True
-        except ImportError:
-            _PSUTIL_AVAILABLE = False
-
-    if not _PSUTIL_AVAILABLE:
+    try:
+        import psutil
+    except ImportError:
         return None
-
-    import psutil
 
     process = psutil.Process()
     memory_bytes = process.memory_info().rss
@@ -106,13 +92,3 @@ def check_large_array_memory(*arrays: np.ndarray) -> dict[str, float] | None:
         metrics["process_memory_mb"] = round(process_memory, 2)
 
     return metrics
-
-
-def _reset_psutil_cache() -> None:
-    """Reset the cached psutil availability flag for test isolation.
-
-    This function is intended for testing purposes only, allowing tests to reset
-    the module-level cache and re-evaluate psutil availability.
-    """
-    global _PSUTIL_AVAILABLE
-    _PSUTIL_AVAILABLE = None

--- a/tests/test_performance_metrics.py
+++ b/tests/test_performance_metrics.py
@@ -13,12 +13,7 @@ import pytest
 from climate_indices import compute, indices
 from climate_indices.eto import eto_hargreaves
 from climate_indices.logging_config import _reset_logging_for_testing, configure_logging
-from climate_indices.performance import (
-    LARGE_ARRAY_THRESHOLD_BYTES,
-    _reset_psutil_cache,
-    check_large_array_memory,
-    get_process_memory_mb,
-)
+from climate_indices.performance import LARGE_ARRAY_THRESHOLD_BYTES, check_large_array_memory, get_process_memory_mb
 
 
 @pytest.fixture(autouse=False)
@@ -74,48 +69,19 @@ class TestGetProcessMemoryMb:
 
     def test_returns_float_when_psutil_available(self):
         """get_process_memory_mb returns float when psutil is installed."""
-        # reset cache to ensure fresh import attempt
-        _reset_psutil_cache()
-
-        # attempt to import psutil
         try:
             import psutil  # noqa: F401
-
-            psutil_available = True
         except ImportError:
-            psutil_available = False
-
-        if psutil_available:
-            result = get_process_memory_mb()
-            assert isinstance(result, float)
-            assert result > 0
-        else:
             pytest.skip("psutil not installed")
+
+        result = get_process_memory_mb()
+        assert isinstance(result, float)
+        assert result > 0
 
     def test_returns_none_when_psutil_unavailable(self):
         """get_process_memory_mb returns None when psutil is not installed."""
-        # reset cache
-        _reset_psutil_cache()
-
-        # mock psutil as unavailable
         with patch.dict("sys.modules", {"psutil": None}):
-            with patch("builtins.__import__", side_effect=ImportError):
-                result = get_process_memory_mb()
-                assert result is None
-
-    def test_caches_psutil_availability(self):
-        """get_process_memory_mb caches psutil availability check."""
-        # reset cache
-        _reset_psutil_cache()
-
-        # first call
-        result1 = get_process_memory_mb()
-
-        # second call should use cached result (no new import attempt)
-        result2 = get_process_memory_mb()
-
-        # both calls should return same type
-        assert type(result1) is type(result2)
+            assert get_process_memory_mb() is None
 
 
 class TestCheckLargeArrayMemory:
@@ -171,9 +137,6 @@ class TestCheckLargeArrayMemory:
 
     def test_includes_process_memory_when_psutil_available(self):
         """check_large_array_memory includes process_memory_mb when psutil available."""
-        # reset cache
-        _reset_psutil_cache()
-
         # check if psutil is available
         try:
             import psutil  # noqa: F401
@@ -199,13 +162,8 @@ class TestCheckLargeArrayMemory:
 
     def test_excludes_process_memory_when_psutil_unavailable(self):
         """check_large_array_memory excludes process_memory_mb when psutil unavailable."""
-        # reset cache
-        _reset_psutil_cache()
-
         # mock psutil as unavailable
         with patch.dict("sys.modules", {"psutil": None}):
-            # trigger cache update
-            get_process_memory_mb()
 
             class MockArray:
                 nbytes = LARGE_ARRAY_THRESHOLD_BYTES + 1000


### PR DESCRIPTION
## Summary
- import `psutil` directly in `get_process_memory_mb` and return `None` when unavailable
- remove the redundant availability cache, reset hook, and cache-specific tests

## Testing
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uv run pytest`

## Summary by Sourcery

Simplify optional psutil support by removing availability caching and its associated test infrastructure.

Enhancements:
- Simplify optional psutil handling by attempting the import on each memory-metrics request and returning no metric when it is unavailable.

Tests:
- Remove cache-specific test hooks and coverage while retaining tests for psutil-present and psutil-absent behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Process memory metrics now detect the availability of system monitoring support on each request, improving behavior when that support changes at runtime.
  - Memory usage is gracefully omitted when the monitoring library is unavailable.

- **Tests**
  - Updated performance metric tests to reflect dynamic availability detection.
  - Removed coverage for the previous cached-availability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->