### PR TITLE
docs: record Explorer provenance glossary

### DIFF
--- a/docs/explorer/CONTEXT.md
+++ b/docs/explorer/CONTEXT.md
@@ -5,12 +5,16 @@ This context defines the shared language for planning and operating the interact
 ## Language
 
 **Trusted Local Mode**:
-Single-user explorer operation within the operator's trust boundary, with access to local or remote data sources selected by that operator.
+Single-user explorer operation within the operator's trust boundary, with access to local or remote data sources selected by that operator. It assumes trusted users and inputs rather than providing hostile multi-user isolation.
 _Avoid_: Desktop mode, developer mode
 
 **Curated Hosted Demo Mode**:
-Public explorer operation for untrusted visitors using only fixed, allowlisted, read-only data sources, without visitor-supplied data, durable identity, or persistent sessions.
+Public explorer operation for untrusted visitors using only fixed, allowlisted, read-only data sources, without visitor-supplied data, durable identity, or persistent sessions. Its visitor input boundary is limited to controls exposed by its Index Capabilities; it does not accept visitor-provided sources, expressions, configuration, or code.
 _Avoid_: Hosted mode, cloud mode, production mode
+
+**Static Open-Science Gallery**:
+A non-interactive publication surface for pre-generated maps, exports, and provenance derived from registered Derived Index Cubes. It is a peer of the explorer, not an explorer mode or computation interface.
+_Avoid_: Explorer, interactive demo, hosted explorer
 
 **Computation Specification**:
 A complete declaration of a climate-index derivation, including its source identity, input variable, index parameters, calibration period, periodicity, and missing-data policy.
@@ -24,9 +28,25 @@ _Avoid_: Source URL, source path, connection string
 The set of available Source Descriptors and the rules for resolving them to accessible datasets without embedding credentials.
 _Avoid_: Dataset list, URL list
 
+**Resolved Source**:
+A runtime-accessible dataset produced by resolving a Source Descriptor and verifying its declared revision. Any credentials used during resolution remain outside the Source Descriptor and Computation Specification.
+_Avoid_: Source URL, open dataset
+
+**Credential Provider**:
+The out-of-band authority that supplies secrets needed to resolve a Source Descriptor without exposing them to computations or provenance.
+_Avoid_: Embedded credentials, credential fields
+
+**Derivation Pipeline**:
+The application-neutral sequence from resolving and verifying a Source Descriptor through applying a Computation Specification with the core library to validating and atomically registering its Derived Index Cube. A Computation Attempt executes this sequence; CLI/UI invocation and Exploration Views are outside it.
+_Avoid_: Pipeline run, UI workflow, CLI workflow
+
 **Demonstration Sample**:
 A provenance-verified, authentically sourced, reduced nClimGrid precipitation dataset used for the explorer demonstration and its performance acceptance. It is distinct from the synthetic deterministic fixture used by automated tests.
 _Avoid_: Example fixture, generated benchmark data
+
+**Demonstration Sample Source Manifest**:
+The immutable record of selected NCEI source objects, their retrieval-time verification evidence, and the precise reduction from which one fixed Demonstration Sample version is produced. A source object's fixed name or time coordinate does not itself make it immutable.
+_Avoid_: Archive revision, latest nClimGrid data
 
 **Index Capability**:
 A supported combination of climate index, required input roles, periodicity, configurable parameters, and validation constraints exposed by the explorer.
@@ -40,6 +60,10 @@ _Avoid_: Pipeline run, Dask task, request
 One execution try within a Computation Job; a retry creates a new attempt without replacing earlier history.
 _Avoid_: Retry, rerun
 
+**Job Observation**:
+A visitor's non-owning association with a shared Computation Job for following its status, progress, and outcome. Ending a Job Observation never cancels the Computation Job.
+_Avoid_: Job ownership, visitor job, session job
+
 **Derived Index Cube**:
 An immutable, fully materialized gridded climate-index result that has passed validation and been atomically registered. It is shared by Computation Key rather than owned by a UI session or visitor; partial output is not a Derived Index Cube.
 _Avoid_: Output file, result dataset, cache entry, session result
@@ -52,8 +76,12 @@ _Avoid_: Job ID, cache key, filename
 A Derived Index Cube that an operator has explicitly protected from automated retention policies. Active use can delay eviction but does not itself pin the cube.
 _Avoid_: Visitor-owned result, session-owned result
 
+**Output Provenance Manifest**:
+The versioned, immutable, publication-specific account of a Derived Index Cube's scientific identity, derivation, and artifact integrity. It accompanies the artifact, is retained in its Derived Index Cube Record, and is replaced on rematerialization even when the Computation Key is unchanged. It is distinct from Fixture Provenance and lightweight CF output metadata.
+_Avoid_: Fixture provenance, CF output metadata
+
 **Derived Index Cube Record**:
-The durable account of a Derived Index Cube's derivation, publication, availability, and eviction state. It remains after artifact eviction so the result's prior existence and reproducibility remain explainable.
+The durable account of a Derived Index Cube's derivation, publication, availability, and eviction state. It preserves the Output Provenance Manifest and operational history after artifact eviction so the result's prior existence and reproducibility remain explainable.
 _Avoid_: Cache metadata, tombstone
 
 **Exploration View**:

--- a/docs/explorer/CONTEXT.md
+++ b/docs/explorer/CONTEXT.md
@@ -77,7 +77,7 @@ A Derived Index Cube that an operator has explicitly protected from automated re
 _Avoid_: Visitor-owned result, session-owned result
 
 **Output Provenance Manifest**:
-The versioned, immutable, publication-specific account of a Derived Index Cube's scientific identity, derivation, and artifact integrity. It accompanies the artifact, is retained in its Derived Index Cube Record, and is replaced on rematerialization even when the Computation Key is unchanged. It is distinct from Fixture Provenance and lightweight CF output metadata.
+The versioned, immutable, publication-specific account of one registered Derived Index Cube's scientific identity, derivation, and artifact integrity. Its canonical form is a sibling `provenance.json`, serialized as RFC 8785 JSON Canonicalization Scheme bytes; the Derived Index Cube Record, not the manifest itself, stores those bytes and their digest, so the manifest never contains its own hash. Its artifact checksum covers only the published NetCDF or Zarr payload, excluding the sibling manifest, and the artifact's CF metadata carries only a relative `climate_indices_provenance_uri` pointer rather than duplicating manifest content. Attempts, retries, timing, workers, logs, diagnostics, and eviction history belong only to the Derived Index Cube Record. A rematerialization for the same Computation Key produces a new cube, manifest, and artifact checksum rather than updating the prior ones in place. It is distinct from Fixture Provenance and lightweight CF output metadata.
 _Avoid_: Fixture provenance, CF output metadata
 
 **Derived Index Cube Record**:


### PR DESCRIPTION
## Summary

- preserve approved Explorer terms for source resolution, Derivation Pipeline, gallery publication, and job observation
- define Output Provenance Manifest and clarify its relationship to the Derived Index Cube Record
- record Trusted Local Mode and Curated Hosted Demo Mode trust-boundary language

## Decision sources

- [Reconcile Explorer contracts with existing pipeline and demo-platform work](https://github.com/monocongo/climate_indices/issues/724)
- [Design shared typed computation and publication service boundaries](https://github.com/monocongo/climate_indices/issues/727)
- [Specify the Output Provenance Manifest identity and checksum contract](https://github.com/monocongo/climate_indices/issues/728)

## Validation

- `git diff --check`

## Summary by Sourcery

Document the approved Explorer glossary and provenance contracts for computation, publication, and trust boundaries.

Enhancements:
- Expand Explorer terminology to define source resolution, credential handling, derivation pipelines, demonstration-source manifests, job observation, and static gallery publication.
- Document the Output Provenance Manifest contract and clarify how provenance and operational history are retained by the Derived Index Cube Record.
- Clarify trust boundaries and visitor input restrictions for local and curated hosted Explorer modes.

Documentation:
- Record the approved Explorer provenance, publication, computation, and trust-boundary glossary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the climate-index explorer glossary with terms covering sources, credentials, derivation pipelines, demonstrations, observations, provenance, and publication surfaces.
  * Clarified trusted-user assumptions for local and hosted demo modes, with visitor input limited to Index Capabilities.
  * Defined the Static Open-Science Gallery as a non-interactive publication surface.
  * Documented provenance manifest serialization, storage, checksums, metadata, operational history, rematerialization, and preservation after artifact eviction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->