### PR TITLE
feat(fire): add the Fosberg Fire Weather Index

### DIFF
--- a/src/climate_indices/fire.py
+++ b/src/climate_indices/fire.py
@@ -126,6 +126,12 @@ def _ffwi(
     return _moisture_damping(equilibrium_moisture_content) * np.sqrt(1.0 + wind_speed_mph**2) / _FFWI_NORMALIZER
 
 
+def _as_float_array(values: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """Coerce to float64, turning masked elements into NaN instead of dropping the mask."""
+    filled = np.ma.asarray(values, dtype=np.float64).filled(np.nan)
+    return np.asarray(filled, dtype=np.float64)
+
+
 def fosberg_ffwi(
     temperature_celsius: npt.ArrayLike,
     relative_humidity_percent: npt.ArrayLike,
@@ -161,8 +167,8 @@ def fosberg_ffwi(
 
     Returns:
         FFWI with the broadcast shape of the inputs. NaN where any input is
-        NaN, where relative humidity lies outside [0, 100], or where wind speed
-        is negative.
+        NaN or masked, where relative humidity lies outside [0, 100], or where
+        wind speed is negative.
 
     Raises:
         InvalidArgumentError: If the inputs cannot be broadcast together.
@@ -172,9 +178,9 @@ def fosberg_ffwi(
         >>> round(float(fire.fosberg_ffwi(30.0, 15.0, 10.0)), 2)
         59.24
     """
-    temperature = np.asarray(temperature_celsius, dtype=np.float64)
-    humidity = np.asarray(relative_humidity_percent, dtype=np.float64)
-    wind = np.asarray(wind_speed_meters_per_second, dtype=np.float64)
+    temperature = _as_float_array(temperature_celsius)
+    humidity = _as_float_array(relative_humidity_percent)
+    wind = _as_float_array(wind_speed_meters_per_second)
 
     try:
         temperature, humidity, wind = np.broadcast_arrays(temperature, humidity, wind)

--- a/src/climate_indices/fire.py
+++ b/src/climate_indices/fire.py
@@ -71,10 +71,12 @@ def _equilibrium_moisture_content(
     """Simard (1968) equilibrium moisture content, in percent.
 
     The three regressions were fitted independently and do not meet at the
-    breakpoints. At 10% relative humidity the result jumps by up to about 0.7,
-    with a size and sign that depend on temperature; at 50% it jumps by up to
-    about 0.5. That is a property of the published equations, not of this
-    implementation, and the index inherits a jump of roughly one unit.
+    breakpoints. At 10% relative humidity the result jumps by roughly 0.5 to
+    0.7 near typical fire-weather temperatures, with a size and sign that
+    depend on temperature and grow larger toward the cold end of this
+    module's supported range; at 50% the jump is smaller, roughly 0.5. That
+    is a property of the published equations, not of this implementation,
+    and the index inherits a jump of roughly one unit.
 
     Args:
         temperature_fahrenheit: Air temperature, degrees Fahrenheit.
@@ -163,7 +165,10 @@ def fosberg_ffwi(
             fuel moisture and a 30 mph wind, giving the conventional 0-100
             scale. NCEP's GEMPAK implementation does not clamp, and some
             studies deliberately keep values above 100; pass ``False`` to
-            reproduce them.
+            reproduce them. This only affects the upper bound: the moisture
+            content clamp that keeps the index at 0 rather than negative in
+            cold, saturated air (see ``_moisture_damping``) is always
+            applied, independent of this flag.
 
     Returns:
         FFWI with the broadcast shape of the inputs. NaN where any input is

--- a/src/climate_indices/fire.py
+++ b/src/climate_indices/fire.py
@@ -1,0 +1,240 @@
+"""Fire-weather indices computed from standard meteorological inputs.
+
+This module is the NumPy layer of the fire-weather family tracked in #793. It
+currently provides the Fosberg Fire Weather Index, which is weather-only and
+carries no state between time steps.
+
+References
+----------
+Fosberg, M.A. (1978) Weather in wildland fire management: the fire weather
+index. Conference on Sierra Nevada Meteorology, Lake Tahoe, CA, 1-4.
+
+Simard, A.J. (1968) The moisture content of forest fuels - I. A review of the
+basic concepts. Canadian Department of Forest and Rural Development, Forest
+Fire Research Institute, Information Report FF-X-14.
+
+Goodrick, S.L. (2002) Modification of the Fosberg fire weather index to include
+drought. International Journal of Wildland Fire, 11, 205-211.
+
+NCEP GEMPAK, ``pd_fosb`` / ``pr_fosb`` (T. Lee, 2003): the operational
+implementation behind the ``FOSINDX`` GRIB2 parameter.
+https://github.com/Unidata/gempak
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import numpy.typing as npt
+
+from climate_indices.exceptions import InvalidArgumentError
+from climate_indices.logging_config import get_logger
+from climate_indices.performance import check_large_array_memory
+
+# retrieve structlog logger for this module
+_logger = get_logger(__name__)
+
+# declare the function names that should be included in the public API for this module
+__all__ = ["fosberg_ffwi"]
+
+# Simard (1968) equilibrium moisture content regressions, one per relative
+# humidity range, with the coefficients of NCEP's operational GEMPAK code.
+# Published restatements print the middle-range temperature coefficient as
+# 0.01478 rather than 0.014784; across physical temperatures that moves the
+# moisture content by less than 0.0005 and the index by less than 0.01.
+_EMC_LOW_RH = (0.03229, 0.281073, 0.000578)
+_EMC_MID_RH = (2.22749, 0.160107, 0.014784)
+_EMC_HIGH_RH = (21.0606, 0.005565, 0.00035, 0.483199)
+
+# Relative humidity breakpoints, upper bound inclusive as in GEMPAK. The
+# published equations are written "h < 10" and "10 < h <= 50", which leaves
+# exactly 10% in neither range.
+_RH_BREAK_LOW = 10.0
+_RH_BREAK_HIGH = 50.0
+
+# moisture content at which the damping coefficient reaches zero
+_EMC_EXTINCTION = 30.0
+
+# scales the index to 100 at zero fuel moisture and a 30 mph wind
+_FFWI_NORMALIZER = 0.3002
+_FFWI_CAP = 100.0
+
+# exact, by the definition of the international mile
+_METERS_PER_SECOND_PER_MPH = 0.44704
+
+
+def _equilibrium_moisture_content(
+    temperature_fahrenheit: npt.NDArray[np.float64],
+    relative_humidity_percent: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Simard (1968) equilibrium moisture content, in percent.
+
+    The three regressions were fitted independently and do not meet at the
+    breakpoints. At 10% relative humidity the result jumps by up to about 0.7,
+    with a size and sign that depend on temperature; at 50% it jumps by up to
+    about 0.5. That is a property of the published equations, not of this
+    implementation, and the index inherits a jump of roughly one unit.
+
+    Args:
+        temperature_fahrenheit: Air temperature, degrees Fahrenheit.
+        relative_humidity_percent: Relative humidity, percent.
+
+    Returns:
+        Equilibrium moisture content, percent.
+    """
+    t = temperature_fahrenheit
+    h = relative_humidity_percent
+
+    a, b, c = _EMC_LOW_RH
+    low = a + b * h - c * h * t
+
+    d, e, f = _EMC_MID_RH
+    mid = d + e * h - f * t
+
+    g, k, p, q = _EMC_HIGH_RH
+    high = g + k * h * h - p * h * t - q * h
+
+    return np.where(h <= _RH_BREAK_LOW, low, np.where(h <= _RH_BREAK_HIGH, mid, high))
+
+
+def _moisture_damping(equilibrium_moisture_content: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Fosberg's moisture damping coefficient.
+
+    With ``x = m / 30`` the coefficient ``1 - 2x + 1.5x**2 - 0.5x**3`` factors as
+    ``(1 - x)(0.5x**2 - x + 1)``, and the second factor is positive for every
+    real ``x``. The coefficient is therefore negative exactly when ``m`` exceeds
+    30, which the high-humidity regression reaches in saturated air below about
+    -46 F (-43 C). Clamping ``m`` at 30 keeps the index at zero there rather than
+    letting it go negative.
+
+    Args:
+        equilibrium_moisture_content: Equilibrium moisture content, percent.
+
+    Returns:
+        Damping coefficient in [0, 1] for non-negative moisture content.
+    """
+    x = np.minimum(equilibrium_moisture_content, _EMC_EXTINCTION) / _EMC_EXTINCTION
+    return 1.0 - 2.0 * x + 1.5 * x**2 - 0.5 * x**3
+
+
+def _ffwi(
+    equilibrium_moisture_content: npt.NDArray[np.float64],
+    wind_speed_mph: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Uncapped Fosberg index from moisture content and wind speed in mph."""
+    return _moisture_damping(equilibrium_moisture_content) * np.sqrt(1.0 + wind_speed_mph**2) / _FFWI_NORMALIZER
+
+
+def fosberg_ffwi(
+    temperature_celsius: npt.ArrayLike,
+    relative_humidity_percent: npt.ArrayLike,
+    wind_speed_meters_per_second: npt.ArrayLike,
+    cap_at_100: bool = True,
+) -> npt.NDArray[np.float64]:
+    """Compute the Fosberg Fire Weather Index (FFWI).
+
+    A weather-only index of fire-weather potential from temperature, relative
+    humidity and wind speed (Fosberg, 1978). It carries no state between time
+    steps, so it is computed elementwise: the inputs broadcast against each
+    other and any shape works, including arrays chunked along time.
+
+    Inputs are SI, like the rest of the package and like NCEP's operational
+    implementation. The conversion to the degrees Fahrenheit and miles per
+    hour that the equations are written in happens here and nowhere else.
+
+    Relative humidity exactly at 10% or 50% is assigned to the lower range, as
+    in NCEP's GEMPAK code; the published equations leave exactly 10% in
+    neither range. The moisture regressions are discontinuous at both
+    breakpoints, so the index is too, by roughly one unit.
+
+    Args:
+        temperature_celsius: Air temperature, degrees Celsius.
+        relative_humidity_percent: Relative humidity, percent, in [0, 100].
+        wind_speed_meters_per_second: Wind speed, meters per second,
+            non-negative.
+        cap_at_100: Clamp the index at 100, the value Fosberg assigned to zero
+            fuel moisture and a 30 mph wind, giving the conventional 0-100
+            scale. NCEP's GEMPAK implementation does not clamp, and some
+            studies deliberately keep values above 100; pass ``False`` to
+            reproduce them.
+
+    Returns:
+        FFWI with the broadcast shape of the inputs. NaN where any input is
+        NaN, where relative humidity lies outside [0, 100], or where wind speed
+        is negative.
+
+    Raises:
+        InvalidArgumentError: If the inputs cannot be broadcast together.
+
+    Example:
+        >>> from climate_indices import fire
+        >>> round(float(fire.fosberg_ffwi(30.0, 15.0, 10.0)), 2)
+        59.24
+    """
+    temperature = np.asarray(temperature_celsius, dtype=np.float64)
+    humidity = np.asarray(relative_humidity_percent, dtype=np.float64)
+    wind = np.asarray(wind_speed_meters_per_second, dtype=np.float64)
+
+    try:
+        temperature, humidity, wind = np.broadcast_arrays(temperature, humidity, wind)
+    except ValueError as exc:
+        message = (
+            "Incompatible array shapes for Fosberg FFWI: "
+            f"temperature={temperature.shape}, relative_humidity={humidity.shape}, "
+            f"wind_speed={wind.shape}. The inputs must broadcast together."
+        )
+        _logger.error(message)
+        raise InvalidArgumentError(
+            message,
+            argument_name="temperature_celsius/relative_humidity_percent/wind_speed_meters_per_second",
+            argument_value=f"shapes {temperature.shape}, {humidity.shape}, {wind.shape}",
+            valid_values="Arrays broadcastable to a common shape",
+        ) from exc
+
+    # bind context and emit calculation_started event
+    log = _logger.bind(
+        index_type="fosberg_ffwi",
+        input_shape=temperature.shape,
+        input_elements=temperature.size,
+    )
+    log.info("calculation_started")
+    t0 = time.perf_counter()
+    memory_metrics = check_large_array_memory(temperature, humidity, wind)
+
+    try:
+        # outside the physical range the regressions still return numbers, but
+        # meaningless ones, so treat such values as missing
+        invalid = (humidity < 0.0) | (humidity > 100.0) | (wind < 0.0)
+        invalid_count = int(np.count_nonzero(invalid))
+        if invalid_count > 0:
+            _logger.warning(
+                f"Found {invalid_count} values with relative humidity outside [0, 100] "
+                "or negative wind speed; FFWI is NaN there."
+            )
+
+        temperature_fahrenheit = temperature * 9.0 / 5.0 + 32.0
+        wind_speed_mph = wind / _METERS_PER_SECOND_PER_MPH
+
+        emc = _equilibrium_moisture_content(temperature_fahrenheit, humidity)
+        index = _ffwi(emc, wind_speed_mph)
+        if cap_at_100:
+            index = np.minimum(index, _FFWI_CAP)
+
+        result = np.where(invalid, np.nan, index).astype(np.float64, copy=False)
+        duration_ms = (time.perf_counter() - t0) * 1000.0
+        log.info(
+            "calculation_completed",
+            duration_ms=round(duration_ms, 2),
+            output_shape=result.shape,
+            **(memory_metrics or {}),
+        )
+        return result
+    except Exception as exc:
+        log.error(
+            "calculation_failed",
+            exc_info=True,
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+        )
+        raise

--- a/tests/test_fire.py
+++ b/tests/test_fire.py
@@ -176,6 +176,16 @@ def test_out_of_range_inputs_are_nan() -> None:
     assert np.isfinite(result[3])
 
 
+def test_masked_inputs_are_nan() -> None:
+    """Masked elements count as missing, like NaN, not as the data under the mask."""
+    humidity = np.ma.masked_array([20.0, 20.0, 20.0], mask=[False, True, False])
+    wind = np.ma.masked_array([5, 5, 5], mask=[False, False, True])  # integer data too
+    result = fire.fosberg_ffwi(25.0, humidity, wind)
+    assert not np.ma.isMaskedArray(result)
+    assert np.isfinite(result[0])
+    assert np.isnan(result[1:]).all()
+
+
 def test_edges_of_the_valid_range_are_valid() -> None:
     result = fire.fosberg_ffwi(20.0, np.array([0.0, 100.0]), 0.0)
     assert np.isfinite(result).all()

--- a/tests/test_fire.py
+++ b/tests/test_fire.py
@@ -1,0 +1,245 @@
+"""Tests for the Fosberg Fire Weather Index (#808)."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from climate_indices import fire
+from climate_indices.exceptions import InvalidArgumentError
+
+
+@pytest.fixture(scope="module", autouse=True)
+def disable_logging():
+    """Silence the calculation lifecycle events during these tests."""
+    logging.disable(logging.CRITICAL)
+    yield
+    logging.disable(logging.NOTSET)
+
+
+def _emc(temperature_fahrenheit: float, relative_humidity_percent: float) -> float:
+    return float(
+        fire._equilibrium_moisture_content(
+            np.asarray(temperature_fahrenheit, dtype=np.float64),
+            np.asarray(relative_humidity_percent, dtype=np.float64),
+        )
+    )
+
+
+# ------------------------------------------------------------------------------
+# equilibrium moisture content
+
+
+@pytest.mark.parametrize(
+    ("relative_humidity", "expected"),
+    [
+        pytest.param(5.0, 1.235355, id="low_range"),
+        pytest.param(30.0, 5.99582, id="mid_range"),
+        pytest.param(80.0, 16.06068, id="high_range"),
+    ],
+)
+def test_emc_matches_simard_on_each_range(relative_humidity: float, expected: float) -> None:
+    """Hand-evaluated Simard (1968) regressions at 70 F."""
+    assert _emc(70.0, relative_humidity) == pytest.approx(expected, rel=1e-12)
+
+
+def test_emc_breakpoints_belong_to_the_lower_range() -> None:
+    """10% and 50% use the lower regression, as in NCEP's GEMPAK code.
+
+    The published equations are written "h < 10" and "10 < h <= 50", which
+    leaves exactly 10% in neither range; GEMPAK closes both ranges from above.
+    """
+    just_above_10 = np.nextafter(10.0, np.inf)
+    just_above_50 = np.nextafter(50.0, np.inf)
+
+    assert _emc(70.0, 10.0) == pytest.approx(2.43842, rel=1e-12)
+    assert _emc(70.0, just_above_10) == pytest.approx(2.79368, rel=1e-9)
+    assert _emc(70.0, 50.0) == pytest.approx(9.19796, rel=1e-12)
+    assert _emc(70.0, just_above_50) == pytest.approx(9.58815, rel=1e-9)
+
+
+def test_emc_is_discontinuous_at_the_breakpoints() -> None:
+    """The three regressions do not meet, so continuity cannot be asserted.
+
+    Pinned so that nobody "fixes" the published equations into a smooth curve
+    by accident. At 10% the jump even changes sign with temperature.
+    """
+    below_10, above_10 = _emc(32.0, 10.0), _emc(32.0, np.nextafter(10.0, np.inf))
+    below_50, above_50 = _emc(32.0, 50.0), _emc(32.0, np.nextafter(50.0, np.inf))
+    assert above_10 - below_10 == pytest.approx(0.697412, abs=1e-6)
+    assert above_50 - below_50 == pytest.approx(0.493398, abs=1e-6)
+
+    hot_jump = _emc(110.0, np.nextafter(10.0, np.inf)) - _emc(110.0, 10.0)
+    assert hot_jump == pytest.approx(-0.0049, abs=1e-6)
+
+
+# ------------------------------------------------------------------------------
+# damping coefficient and index
+
+
+def test_calibration_point() -> None:
+    """Zero moisture and a 30 mph wind give 100, to the precision of 0.3002."""
+    value = float(fire._ffwi(np.asarray(0.0), np.asarray(30.0)))
+    assert value == pytest.approx(99.988881, abs=1e-6)
+    assert abs(value - 100.0) < 0.02
+
+
+def test_damping_changes_sign_exactly_at_30() -> None:
+    """eta = (1 - x)(0.5x^2 - x + 1) with the second factor always positive."""
+    x = np.linspace(0.0, 1.5, 301)
+    polynomial = 1.0 - 2.0 * x + 1.5 * x**2 - 0.5 * x**3
+    np.testing.assert_allclose(polynomial, (1.0 - x) * (0.5 * x**2 - x + 1.0), atol=1e-12)
+    assert np.all(0.5 * x**2 - x + 1.0 > 0.0)
+
+    damping = fire._moisture_damping(np.array([0.0, 15.0, 30.0, 40.0]))
+    assert damping[0] == pytest.approx(1.0)
+    assert 0.0 < damping[1] < 1.0
+    assert damping[2] == pytest.approx(0.0, abs=1e-12)
+    assert damping[3] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_saturated_cold_air_gives_zero_not_a_negative_index() -> None:
+    """Below about -43 C at 100% humidity the moisture content exceeds 30."""
+    assert _emc(-58.0, 100.0) > 30.0
+    for cap in (True, False):
+        assert float(fire.fosberg_ffwi(-50.0, 100.0, 5.0, cap_at_100=cap)) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("temperature", "humidity", "wind", "expected"),
+    [
+        pytest.param(30.0, 15.0, 10.0, 59.242107, id="hot_dry_breezy"),
+        pytest.param(25.0, 20.0, 10.0, 55.430582, id="warm_dry_breezy"),
+    ],
+)
+def test_reference_values(temperature: float, humidity: float, wind: float, expected: float) -> None:
+    assert float(fire.fosberg_ffwi(temperature, humidity, wind)) == pytest.approx(expected, rel=1e-7)
+
+
+def test_cap_is_applied_by_default_and_can_be_turned_off() -> None:
+    assert float(fire.fosberg_ffwi(40.0, 5.0, 25.0)) == 100.0
+    assert float(fire.fosberg_ffwi(40.0, 5.0, 25.0, cap_at_100=False)) == pytest.approx(172.5894, abs=1e-4)
+
+
+def _gempak_pd_fosb(tmpc: np.ndarray, relh: np.ndarray, sped: np.ndarray) -> np.ndarray:
+    """Transcription of NCEP GEMPAK's pd_fosb, in float32 with its own constants."""
+    f32 = np.float32
+    tmpc, relh, sped = (np.asarray(a, dtype=f32) for a in (tmpc, relh, sped))
+    tf = tmpc * f32(9.0 / 5.0) + f32(32.0)
+    smph = sped * f32(1.9425) / f32(0.868976)
+    fw = np.where(
+        relh <= f32(10.0),
+        f32(0.03229) + f32(0.281073) * relh - f32(0.000578) * relh * tf,
+        np.where(
+            relh <= f32(50.0),
+            f32(2.22749) + f32(0.160107) * relh - f32(0.014784) * tf,
+            f32(21.0606) + f32(0.005565) * relh * relh - f32(0.00035) * relh * tf - f32(0.483199) * relh,
+        ),
+    )
+    fwd = fw / f32(30.0)
+    damping = f32(1.0) - f32(2.0) * fwd + f32(1.5) * fwd**2 - f32(0.5) * fwd**3
+    return damping * np.sqrt(f32(1.0) + smph * smph) / f32(0.3002)
+
+
+def test_matches_ncep_gempak() -> None:
+    """Agrees with NCEP's operational implementation behind FOSINDX.
+
+    The tolerance covers GEMPAK's m/s to mph factor, 1.9425 / 0.868976, which is
+    0.069% below the exact 1 / 0.44704. Temperatures stay above -10 C, where
+    GEMPAK's unclamped moisture content cannot exceed 30.
+    """
+    temperature, humidity, wind = np.meshgrid(
+        np.arange(-10.0, 46.0, 5.0),
+        np.array([0.0, 3.0, 10.0, 10.5, 25.0, 50.0, 50.5, 70.0, 100.0]),
+        np.array([0.0, 1.0, 3.0, 7.0, 12.0, 20.0, 30.0]),
+        indexing="ij",
+    )
+    ours = fire.fosberg_ffwi(temperature, humidity, wind, cap_at_100=False)
+    np.testing.assert_allclose(ours, _gempak_pd_fosb(temperature, humidity, wind), rtol=1e-3)
+
+
+# ------------------------------------------------------------------------------
+# inputs
+
+
+def test_out_of_range_inputs_are_nan() -> None:
+    result = fire.fosberg_ffwi(
+        np.array([20.0, 20.0, 20.0, 20.0, np.nan, 20.0]),
+        np.array([-1.0, 100.5, 40.0, 40.0, 40.0, np.nan]),
+        np.array([5.0, 5.0, -0.1, 5.0, 5.0, 5.0]),
+    )
+    assert np.isnan(result[[0, 1, 2, 4, 5]]).all()
+    assert np.isfinite(result[3])
+
+
+def test_edges_of_the_valid_range_are_valid() -> None:
+    result = fire.fosberg_ffwi(20.0, np.array([0.0, 100.0]), 0.0)
+    assert np.isfinite(result).all()
+
+
+def test_inputs_broadcast() -> None:
+    assert fire.fosberg_ffwi(20.0, 30.0, 5.0).shape == ()
+    grid = fire.fosberg_ffwi(np.zeros((3, 1)), np.full((1, 4), 30.0), 5.0)
+    assert grid.shape == (3, 4)
+
+
+def test_incompatible_shapes_raise() -> None:
+    with pytest.raises(InvalidArgumentError, match="must broadcast together"):
+        fire.fosberg_ffwi(np.zeros(3), np.zeros(4), 5.0)
+
+
+def test_chunked_time_axis_matches_eager() -> None:
+    """Elementwise, so chunking along time changes nothing."""
+    xr = pytest.importorskip("xarray")
+    pytest.importorskip("dask")
+
+    rng = np.random.default_rng(808)
+    shape = (48, 3)
+    dims = ("time", "station")
+    temperature = xr.DataArray(rng.uniform(-5.0, 40.0, shape), dims=dims)
+    humidity = xr.DataArray(rng.uniform(0.0, 100.0, shape), dims=dims)
+    wind = xr.DataArray(rng.uniform(0.0, 20.0, shape), dims=dims)
+
+    eager = fire.fosberg_ffwi(temperature.values, humidity.values, wind.values)
+    chunked = xr.apply_ufunc(
+        fire.fosberg_ffwi,
+        temperature.chunk({"time": 12}),
+        humidity.chunk({"time": 12}),
+        wind.chunk({"time": 12}),
+        dask="parallelized",
+        output_dtypes=[np.float64],
+    )
+    np.testing.assert_array_equal(chunked.compute().values, eager)
+
+
+# ------------------------------------------------------------------------------
+# properties
+
+_temperature = st.floats(min_value=-60.0, max_value=55.0, allow_nan=False)
+_humidity = st.floats(min_value=0.0, max_value=100.0, allow_nan=False)
+_wind = st.floats(min_value=0.0, max_value=60.0, allow_nan=False)
+
+
+@given(temperature=_temperature, humidity=_humidity, wind=_wind)
+@settings(max_examples=200, deadline=None)
+def test_capped_index_stays_within_0_and_100(temperature: float, humidity: float, wind: float) -> None:
+    value = float(fire.fosberg_ffwi(temperature, humidity, wind))
+    assert 0.0 <= value <= 100.0
+
+
+@given(temperature=_temperature, humidity=_humidity, wind=_wind)
+@settings(max_examples=200, deadline=None)
+def test_uncapped_index_is_never_negative(temperature: float, humidity: float, wind: float) -> None:
+    assert float(fire.fosberg_ffwi(temperature, humidity, wind, cap_at_100=False)) >= 0.0
+
+
+@given(temperature=_temperature, humidity=_humidity, wind=_wind, extra=_wind)
+@settings(max_examples=200, deadline=None)
+def test_index_does_not_decrease_with_wind(temperature: float, humidity: float, wind: float, extra: float) -> None:
+    slower = float(fire.fosberg_ffwi(temperature, humidity, wind, cap_at_100=False))
+    faster = float(fire.fosberg_ffwi(temperature, humidity, wind + extra, cap_at_100=False))
+    assert faster >= slower - 1e-12

--- a/tests/test_fire.py
+++ b/tests/test_fire.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -106,7 +107,7 @@ def test_saturated_cold_air_gives_zero_not_a_negative_index() -> None:
     """Below about -43 C at 100% humidity the moisture content exceeds 30."""
     assert _emc(-58.0, 100.0) > 30.0
     for cap in (True, False):
-        assert float(fire.fosberg_ffwi(-50.0, 100.0, 5.0, cap_at_100=cap)) == 0.0
+        assert float(fire.fosberg_ffwi(-50.0, 100.0, 5.0, cap_at_100=cap)) == pytest.approx(0.0, abs=1e-9)
 
 
 @pytest.mark.parametrize(
@@ -121,12 +122,23 @@ def test_reference_values(temperature: float, humidity: float, wind: float, expe
 
 
 def test_cap_is_applied_by_default_and_can_be_turned_off() -> None:
-    assert float(fire.fosberg_ffwi(40.0, 5.0, 25.0)) == 100.0
+    assert float(fire.fosberg_ffwi(40.0, 5.0, 25.0)) == pytest.approx(100.0)
     assert float(fire.fosberg_ffwi(40.0, 5.0, 25.0, cap_at_100=False)) == pytest.approx(172.5894, abs=1e-4)
 
 
 def _gempak_pd_fosb(tmpc: np.ndarray, relh: np.ndarray, sped: np.ndarray) -> np.ndarray:
-    """Transcription of NCEP GEMPAK's pd_fosb, in float32 with its own constants."""
+    """Transcription of NCEP GEMPAK's pd_fosb, in float32 with its own constants.
+
+    Note this shares its Simard/GEMPAK coefficients with ``fire.py`` by
+    construction, so `test_matches_ncep_gempak` below checks formula
+    structure, branch selection, and unit conversion against an
+    independently-written float32 implementation; it cannot catch a
+    coefficient mistranscribed identically in both places. The reference
+    values in `test_reference_values` and `test_emc_matches_simard_on_each_range`
+    are pinned directly from these same coefficients too. An authoritative,
+    independently-sourced FFWI dataset (e.g. a captured real GEMPAK run) would
+    close that gap; none was available while writing this test.
+    """
     f32 = np.float32
     tmpc, relh, sped = (np.asarray(a, dtype=f32) for a in (tmpc, relh, sped))
     tf = tmpc * f32(9.0 / 5.0) + f32(32.0)
@@ -198,8 +210,61 @@ def test_inputs_broadcast() -> None:
 
 
 def test_incompatible_shapes_raise() -> None:
-    with pytest.raises(InvalidArgumentError, match="must broadcast together"):
+    with pytest.raises(InvalidArgumentError, match="must broadcast together") as exc_info:
         fire.fosberg_ffwi(np.zeros(3), np.zeros(4), 5.0)
+
+    assert exc_info.value.argument_name == (
+        "temperature_celsius/relative_humidity_percent/wind_speed_meters_per_second"
+    )
+    assert exc_info.value.valid_values == "Arrays broadcastable to a common shape"
+    assert "(3,)" in exc_info.value.argument_value
+    assert "(4,)" in exc_info.value.argument_value
+
+
+def test_accepts_plain_python_sequences() -> None:
+    """Non-numpy array-likes broadcast and coerce through the public API."""
+    result = fire.fosberg_ffwi([20.0, 25.0], [30, 90], [1, 10])
+    assert result.shape == (2,)
+    assert np.isfinite(result).all()
+
+
+def test_calculation_failure_logs_and_propagates() -> None:
+    """An internal failure emits calculation_failed and re-raises, not swallowed."""
+    mock_logger = mock.MagicMock()
+    mock_logger.bind.return_value = mock_logger
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("synthetic failure")
+
+    with (
+        mock.patch.object(fire, "_logger", mock_logger),
+        mock.patch.object(fire, "_equilibrium_moisture_content", side_effect=_raise),
+        pytest.raises(RuntimeError, match="synthetic failure"),
+    ):
+        fire.fosberg_ffwi(20.0, 30.0, 5.0)
+
+    mock_logger.info.assert_called_once_with("calculation_started")
+    failed_calls = [call for call in mock_logger.error.call_args_list if call.args[0] == "calculation_failed"]
+    assert len(failed_calls) == 1
+    assert failed_calls[0].kwargs["error_type"] == "RuntimeError"
+    assert "synthetic failure" in failed_calls[0].kwargs["error_message"]
+
+
+def test_large_array_memory_metrics_are_logged() -> None:
+    """calculation_completed includes memory metrics when check_large_array_memory reports them."""
+    mock_logger = mock.MagicMock()
+    mock_logger.bind.return_value = mock_logger
+
+    with (
+        mock.patch.object(fire, "_logger", mock_logger),
+        mock.patch.object(fire, "check_large_array_memory", return_value={"array_memory_mb": 1234.5}),
+    ):
+        result = fire.fosberg_ffwi(20.0, 30.0, 5.0)
+
+    assert np.isfinite(result)
+    completed_calls = [call for call in mock_logger.info.call_args_list if call.args[0] == "calculation_completed"]
+    assert len(completed_calls) == 1
+    assert completed_calls[0].kwargs["array_memory_mb"] == 1234.5
 
 
 def test_chunked_time_axis_matches_eager() -> None:


### PR DESCRIPTION
Refs #808 — the NumPy-layer part. What is deliberately left out is listed at the end.

Adds `src/climate_indices/fire.py` with `fire.fosberg_ffwi()`, following the layout and name proposed in #794: a flat `fire.py`, `fosberg_ffwi`, no bare `fwi`. #794 is still open, so every choice below is a proposal and easy to change.

## Source of truth

I treated NCEP's GEMPAK code (`pd_fosb.c` / `pr_fosb.f`) as the reference, since it is the operational implementation behind the `FOSINDX` parameter the issue cites. It disagrees with the published restatements in two places, and I followed GEMPAK in both:

- **Coefficient.** GEMPAK uses `0.014784` for the mid-range temperature term; Goodrick (2002) and later papers print `0.01478`. Across physical temperatures the difference is under 0.0005 in moisture content and under 0.01 in the index.
- **Breakpoints.** The papers write `h < 10` and `10 < h <= 50`, which leaves exactly 10% in neither range. GEMPAK closes both ranges from above: `<= 10` and `<= 50`.

## One acceptance criterion cannot hold as written

> Continuity verified at the piecewise RH breakpoints

The three Simard regressions were fitted independently and do not meet:

| | jump at 10% RH | jump at 50% RH |
| --- | ---: | ---: |
| 32 °F | +0.6974 | +0.4934 |
| 110 °F | −0.0049 | — |

At 10% the jump even changes sign with temperature, and the index inherits a step of roughly one unit. So instead of continuity, the tests pin the branch assignment at both breakpoints and the size of these jumps, so that a future attempt to smooth the equations fails loudly rather than silently changing results.

## Decisions the issue asked for

**Units.** Inputs are SI (°C, %, m/s), like the rest of the package and like GEMPAK. The conversion to the °F and mph the equations are written in happens in one place, using the exact 1 mph = 0.44704 m/s.

**The 100 cap.** It is on by default, giving the conventional 0–100 scale. `cap_at_100=False` reproduces GEMPAK, which never clamps, and studies that deliberately keep values above 100.

**Negative values.** With `x = m / 30`, the damping coefficient factors as `(1 − x)(0.5x² − x + 1)`, and the second factor is positive for every real `x`. So η < 0 exactly when `m > 30`. The high-humidity regression gets there in saturated air below about −46 °F (−43 °C), and GEMPAK returns a negative index there. Here `m` is clamped at 30, which gives zero instead.

**Out-of-range inputs.** Relative humidity outside [0, 100] and negative wind speed give NaN, with a logged warning. GEMPAK only rejects RH < 0. Reanalysis RH can come in marginally above 100. If you would rather clip than mask, it is a one-line change.

## Validation

- **Against GEMPAK:** 756 points (12 temperatures × 9 humidities, including both sides of each breakpoint, × 7 wind speeds), transcribed in float32 with GEMPAK's own constants. The maximum relative difference is 6.9e-4. All of it comes from GEMPAK's m/s → mph factor, `1.9425 / 0.868976`, which is 0.069% below the exact value.
- **Calibration:** zero moisture and a 30 mph wind give 99.9889, not exactly 100, because `0.3002` is itself rounded.
- **Chunking:** a dask-chunked time axis through `xr.apply_ufunc` matches the eager result exactly.
- **Properties (Hypothesis):** the capped index stays within [0, 100], the uncapped one is never negative, and the index never decreases as wind increases. I did not assert monotonicity in humidity: the sign flip at 10% RH breaks it.

It follows the package patterns: structlog `calculation_started` / `completed` / `failed` events, `InvalidArgumentError` for shapes that cannot broadcast, and property-based tests.

`ruff check`, `ruff format --check` and `mypy src/` pass. The full `pytest` suite gives 1243 passed and 0 failed; 385 more are deselected by the default `-m 'not benchmark and not validation'`.

## Not in this PR

- **xarray adapter and CF registry entry.** #798 owns metadata for the fire family, and `test_cf_metadata` pins the exact key set, so adding an entry here would step on it. The chunking test shows that the NumPy function already works under `apply_ufunc`.
- **Top-level re-export.** That is an open question in #794. `from climate_indices import fire` works as it is.

Happy to fold either into this PR if you would rather land them together.

## Summary by Sourcery

Add the Fosberg Fire Weather Index as a weather-only NumPy calculation with validated inputs and comprehensive coverage.

New Features:
- Add the NumPy-layer Fosberg Fire Weather Index for temperature, relative humidity, and wind inputs.
- Support conventional capped results and optional uncapped results for GEMPAK-compatible use.

Enhancements:
- Handle broadcasting, masked and invalid inputs, structured calculation logging, and large-array monitoring in line with package conventions.

Tests:
- Add reference, boundary, GEMPAK comparison, input validation, chunking, logging, and property-based tests for the new index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Fosberg Fire Weather Index (FFWI) to assess fire-weather conditions using temperature, relative humidity, and wind speed.
  * Supports array inputs with broadcasting, masked values, optional capping at 100, and chunked evaluations.

* **Bug Fixes**
  * Invalid humidity or negative wind-speed values now produce warnings and `NaN` results.
  * Inputs that cannot be broadcast together are rejected with a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->